### PR TITLE
Remove one of the duplicate i++ in the main-loop

### DIFF
--- a/riscv-blink/src/main.c
+++ b/riscv-blink/src/main.c
@@ -40,7 +40,6 @@ int main(void) {
     irq_setie(0);
     int i = 0;
     while (1) {
-        i++;
         color_wheel(i++);
         msleep(80);
     }


### PR DESCRIPTION
This also speeds up the speed of the rgb animation