### PR TITLE
riscv-blink: Makefile: use CROSS_COMPILE instead of TRGT

### DIFF
--- a/riscv-blink/Makefile
+++ b/riscv-blink/Makefile
@@ -2,14 +2,14 @@ GIT_VERSION := $(shell git describe --tags)
 
 # Earlier versions of the Raspberry Pi image only had riscv32-gcc
 ifneq (,$(wildcard /usr/bin/riscv32-unknown-elf-gcc))
-TRGT       ?= riscv32-unknown-elf-
+CROSS_COMPILE       ?= riscv32-unknown-elf-
 else
-TRGT       ?= riscv64-unknown-elf-
+CROSS_COMPILE       ?= riscv64-unknown-elf-
 endif
 
-CC         := $(TRGT)gcc
-CXX        := $(TRGT)g++
-OBJCOPY    := $(TRGT)objcopy
+CC         := $(CROSS_COMPILE)gcc
+CXX        := $(CROSS_COMPILE)g++
+OBJCOPY    := $(CROSS_COMPILE)objcopy
 
 RM         := rm -rf
 COPY       := cp -a


### PR DESCRIPTION
The CROSS_COMPILE variable is widely used among free and open
source projects like Linux, u-boot, etc.

Signed-off-by: Denis 'GNUtoo' Carikli <GNUtoo@cyberdimension.org>