### PR TITLE
riscv-usb-cdcacm: Makefile: use CROSS_COMPILE instead of TRGT

### DIFF
--- a/riscv-usb-cdcacm/Makefile
+++ b/riscv-usb-cdcacm/Makefile
@@ -2,14 +2,14 @@ GIT_VERSION := $(shell git describe --tags)
 
 # There is no 64-bit gcc on Raspberry Pi, so use the 32-bit version
 ifneq (,$(wildcard /etc/rpi-issue))
-TRGT       ?= riscv32-unknown-elf-
+CROSS_COMPILE       ?= riscv32-unknown-elf-
 else
-TRGT       ?= riscv64-unknown-elf-
+CROSS_COMPILE       ?= riscv64-unknown-elf-
 endif
 
-CC         := $(TRGT)gcc
-CXX        := $(TRGT)g++
-OBJCOPY    := $(TRGT)objcopy
+CC         := $(CROSS_COMPILE)gcc
+CXX        := $(CROSS_COMPILE)g++
+OBJCOPY    := $(CROSS_COMPILE)objcopy
 
 RM         := rm -rf
 COPY       := cp -a


### PR DESCRIPTION
The CROSS_COMPILE variable is widely used among free and open
source projects like Linux, u-boot, etc.

Signed-off-by: Denis 'GNUtoo' Carikli <GNUtoo@cyberdimension.org>