### PR TITLE
riscv-blink: Remove blink rate override

### DIFF
--- a/riscv-blink/src/main.c
+++ b/riscv-blink/src/main.c
@@ -45,8 +45,6 @@ int main(void) {
     irq_setie(1);
     usb_init();
     rgb_init();
-    rgb_write(100000 / 64000 - 1, LEDDBR);
-
     usb_connect();
     int i = 0;
     while (1) {


### PR DESCRIPTION
Remove the blink rate modification that's supposed to be added during the workshop. It looks like it got added by accident in #46