### PR TITLE
This adds a BASIC touch support to the verilog blink example

### DIFF
--- a/verilog-blink/blink.v
+++ b/verilog-blink/blink.v
@@ -55,6 +55,10 @@ module blink (
     output usb_dp,
     output usb_dn,
     output usb_dp_pu,
+    input touch_1,
+    output touch_2,
+    input touch_3,
+    output touch_4,
     input clki         // Clock
 );
 
@@ -95,9 +99,9 @@ module blink (
     ) RGBA_DRIVER (
         .CURREN(1'b1),
         .RGBLEDEN(1'b1),
-        .`BLUEPWM(counter[26]),     // Blue
-        .`REDPWM(counter[27]),      // Red
-        .`GREENPWM(counter[28]),    // Green
+        .`BLUEPWM(!touch_1),     // Blue
+        .`REDPWM(!touch_3),      // Red
+        .`GREENPWM(!(touch_1 | touch_3)),    // Green
         .RGB0(rgb0),
         .RGB1(rgb1),
         .RGB2(rgb2)
@@ -106,5 +110,7 @@ module blink (
     // For more information see the iCE40 UltraPlus LED Driver Usage Guide, pages 19-20
     //
     // https://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/IK/ICE40LEDDriverUsageGuide.ashx?document_id=50668
+    assign touch_2 = 0;
+    assign touch_4 = 0;
 
 endmodule

--- a/verilog-blink/pcf/fomu-pvt.pcf
+++ b/verilog-blink/pcf/fomu-pvt.pcf
@@ -14,9 +14,9 @@ set_io user_1 E4
 set_io user_2 D5
 set_io user_3 E5
 set_io user_4 F5
-set_io touch_1 E4
+set_io touch_1 E4 -pullup yes
 set_io touch_2 D5
-set_io touch_3 E5
+set_io touch_3 E5 -pullup yes
 set_io touch_4 F5
 set_io spi_mosi F1
 set_io spi_miso E1


### PR DESCRIPTION
I wonder if theres a better way to use touch in verilog, i was told that those pads on the pvt version are connected straight to the fpga but in the schematic i see diodes as well. 
any input? 
thanks! :)