### PR TITLE
Make lxbuildenv.py return 0 on success.

### DIFF
--- a/litex/lxbuildenv.py
+++ b/litex/lxbuildenv.py
@@ -592,7 +592,8 @@ elif "LXBUILDENV_REEXEC" not in os.environ:
     try:
         sys.exit(subprocess.Popen(
             [sys.executable] + [sys.argv[0]] + rest).wait())
-    except:
+    except Exception as e:
+        print(e)
         sys.exit(1)
 else:
     # Overwrite the deps directory.


### PR DESCRIPTION
`sys.exit` raises a `SystemExit` exception which causes a bare except to always trigger. IE the below always prints hello.

```python
import sys
try:
	sys.exit(0)
except:
	print("Hello")
```

However, SystemExit doesn't inherit from Exception, so the following works as expected.

```python
import sys
try:
	sys.exit(0)
except Exception:
	print("Hello")
```