### PR TITLE
Note which python version to use building zephyr

### DIFF
--- a/docs/renode-zephyr.rst
+++ b/docs/renode-zephyr.rst
@@ -12,7 +12,10 @@ To install all the dependencies and prepare the environment for building
 the Zephyr application follow the official `Zephyr Getting Started
 Guide <https://docs.zephyrproject.org/latest/getting_started/index.html>`__
 up to point 4. On Linux you can follow the instructions from the point 5
-on installing the Software Development Toolchain. For other operating
+on installing the Software Development Toolchain. The python version
+in the FOMU toolchain may not work; remove it from your PATH before
+attempting to build zephyr.
+For other operating
 systems, if you followed the instructions from the ``Required Software``
 section of this tutorial, you should have a toolchain in ``PATH``.
 


### PR DESCRIPTION
Following all the instructions in order leaves you with python3.6 from
the TOMU toolchain first in your PATH, which doesn't work for building
zephyr.

Add a note to remove it from your PATH.   


Fixes #134 