### PR TITLE
docs: MicroPython example: 2.0.3 firmware

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -131,11 +131,11 @@ They may be different from what you see here:
 
    >>> import machine
    >>> machine.mem32[0xe0007000]
-   1
+   2
    >>> machine.mem32[0xe0007004]
-   8
+   0
    >>> machine.mem32[0xe0007008]
-   7
+   3
    >>>
 
 The ``CSR_VERSION_MODEL_ADDR`` contains a single character that


### PR DESCRIPTION
Update the MicroPython firmware version output example to match the advice to
match the advice at start of tutorial to upgrade to version 2.0.3 firmware.

(Spotted as inconsistency while working through tutorial.)