### PR TITLE
Minor doc tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Other sphinx extensions which are used include;
 
 ```shell-session
 $ cd docs
-$ # Download conda environment with Python utilities
+```
+Download conda environment with Python utilities:
+
+```shell-session
 $ make env
 rm -rf env
 make _download/Miniconda3-latest-Linux-x86_64.sh
@@ -118,7 +121,11 @@ conda-package-handli | 942 KB    | ########################### | 100%
 Preparing transaction: done
 Verifying transaction: done
 Executing transaction: done
-$ # Build the html output
+```
+
+Build the html output:
+
+```shell-session
 $ make html
 Running Sphinx v2.3.1
 loading pickled environment... done
@@ -136,7 +143,11 @@ build succeeded, 15 warnings.
 
 The HTML pages are in _build/html.
 Copying tabs assets
-$ # Start your web browser
+```
+
+Start your web browser:
+
+```shell-session
 $ xdg-open ./_build/html/index.html
 ```
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,8 @@
 # Minimal makefile for Sphinx documentation
 #
 
+SHELL:=/bin/bash
+
 # You can set these variables from the command line.
 SPHINXOPTS      =
 SPHINXBUILD     = [ -e env/bin/activate ] && source env/bin/activate; sphinx-build

--- a/docs/migen.rst
+++ b/docs/migen.rst
@@ -8,8 +8,8 @@ Migen and LiteX
 
 FIXME: Add the Migen and LiteX equivalent for the Verilog above.
 
-Wishbone Bus
-^^^^^^^^^^^^
+Wishbone Bus Basics
+^^^^^^^^^^^^^^^^^^^
 
 Migen is an HDL embedded in Python, and LiteX provides us with a
 Wishbone abstraction layer. There really is no reason we need to include
@@ -112,9 +112,12 @@ of LiteX. Let’s try reading and writing RAM:
    Value at 10000000: 98765432
    $
 
+Wishbone Bus Extension
+^^^^^^^^^^^^^^^^^^^^^^
+
 Aside from that, there’s not much we can *do* with this design. But
-there’s a lot of infrastructure there. So let’s add something (see
-``workshop_rgb.py`` for full example).
+there’s a lot of infrastructure there. So let’s add something we can see
+(``workshop_rgb.py`` contains the completed example).
 
 .. image:: _static/ice40-rgb.jpg
    :width: 100%
@@ -126,8 +129,8 @@ has three outputs: ``RGB0``, ``RGB1``, and ``RGB2``. It also has four
 parameters: ``CURRENT_MODE``, ``RGB0_CURRENT``, ``RGB1_CURRENT``, and
 ``RGB2_CURRENT``.
 
-This block is defined in Verilog, but we can very easily import it as a
-Module into Migen:
+This block is defined in Verilog (as ``SB_RGBA_DRV``), but we can import it as
+a Module into Migen:
 
 .. code:: python
 
@@ -177,10 +180,10 @@ our new register:
 
 .. code:: csv
 
-   csr_register,rgb_output,0xe0006800,1,rw
+   csr_register,fomu_rgb_output,0xe0006800,1,rw
 
-We can use ``wishbone-tool`` to write values to ``0xe0006800`` and see
-them take effect immediately.
+We can use ``wishbone-tool`` to write values to ``0xe0006800`` (or whatever
+your ``build/csr.csv`` says) and see them take effect immediately.
 
 You can see that it takes very little code to take a Signal from HDL and
 expose it on the Wishbone bus.

--- a/docs/verilog.rst
+++ b/docs/verilog.rst
@@ -5,13 +5,12 @@ Verilog on Fomu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The canonical “Hello, world!” of hardware is to blink a LED. The
-directory ``verilog-blink`` contains a Verilog example of a blink
+directory ``verilog/blink-expanded`` contains a Verilog example of a blink
 project. This takes the 48 MHz clock and divides it down by a large
 number so you get an on/off pattern. It also exposes some of the signals
 on the touchpads, making it possible to probe them with an oscilloscope.
 
-Enter the ``verilog-blink`` directory and build the ``verilog-blink``
-demo by using ``make``:
+Enter the ``verilog/blink-expanded`` directory and build the demo by using ``make``:
 
 **Make sure you set the ``FOMU_REV`` value to match your hardware! See
 the Required Hardware section.**
@@ -54,15 +53,15 @@ the Required Hardware section.**
    $
 
 You can load ``blink.dfu`` onto Fomu by using the same ``dfu-util -D``
-command we’ve been using. The LED should begin blinking on and off
-regularly, indicating your bitstream was successfully loaded.
+command we’ve been using. The LED should begin rotating through colors,
+indicating your bitstream was successfully loaded.
 
    When writing HDL, a tool called ``yosys`` is used to convert the
    human readable verilog into a netlist representation, this is called
    synthesis. Once we have the netlist representation a tool called
    ``nextpnr`` performs an operation called “place and route” which
    makes it something that will actually run on the FPGA. This is all
-   done for you using the ``Makefile`` in the ``verilog-blink``
+   done for you using the ``Makefile`` in the ``verilog/blink-expanded``
    directory.
 
    A big feature of ``nextpnr`` over its predecessor, is the fact that

--- a/verilog/blink-basic/README.md
+++ b/verilog/blink-basic/README.md
@@ -2,7 +2,7 @@
 
 A more minimal Verilog example.
 
-Unlike the example in ../verilog-blink it;
+Unlike the example in ../blink-expanded it;
  - **only** works on the **Fomu hacker board**.
  - **only** works on Linux
  - doesn't use any Makefile variables.


### PR DESCRIPTION
Minor tweaks to the main README (to better separate the commands from description of the commands) and to wishbone docs.

Also fix a couple of places where the blink example is using the old name.