### PR TITLE
Add example of changing LED color with wishbone-tool

### DIFF
--- a/docs/migen.rst
+++ b/docs/migen.rst
@@ -189,9 +189,9 @@ our new register:
 
 .. code:: csv
 
-   csr_register,fomu_rgb_output,0xe0006800,1,rw
+   csr_register,fomu_rgb_output,0x60003000,1,rw
 
-We can use ``wishbone-tool`` to write values to ``0xe0006800`` (or whatever
+We can use ``wishbone-tool`` to write values to ``0x60003000`` (or whatever
 your ``build/csr.csv`` says) and see them take effect immediately.
 
 You can see that it takes very little code to take a Signal from HDL and

--- a/docs/migen.rst
+++ b/docs/migen.rst
@@ -194,5 +194,15 @@ our new register:
 We can use ``wishbone-tool`` to write values to ``0x60003000`` (or whatever
 your ``build/csr.csv`` says) and see them take effect immediately.
 
+.. session:: shell-session
+
+   $ wishbone-tool 0x60003000 0x1 # make LED green
+   $ wishbone-tool 0x60003000 0x2 # make LED red
+   $ wishbone-tool 0x60003000 0x3 # make LED yellow   
+   $ wishbone-tool 0x60003000 0x4 # make LED blue
+   $ wishbone-tool 0x60003000 0x5 # make LED teal
+   $ wishbone-tool 0x60003000 0x6 # make LED pink
+   $ wishbone-tool 0x60003000 0x7 # make LED white
+
 You can see that it takes very little code to take a Signal from HDL and
 expose it on the Wishbone bus.


### PR DESCRIPTION
Add examples of changing color using wishbone-tool and fomu_rgb_output CSR:
```
   $ wishbone-tool 0x60003000 0x1 # make LED green
   $ wishbone-tool 0x60003000 0x2 # make LED red
   $ wishbone-tool 0x60003000 0x3 # make LED yellow   
   $ wishbone-tool 0x60003000 0x4 # make LED blue
   $ wishbone-tool 0x60003000 0x5 # make LED teal
   $ wishbone-tool 0x60003000 0x6 # make LED pink
   $ wishbone-tool 0x60003000 0x7 # make LED white
```
NOTE: I have a different address for the CSR so I changed the tutorial to match:
```
pdp7@x1:~/dev/fpga/fomu-workshop/litex/build$ cat csr.csv 
#--------------------------------------------------------------------------------
# Auto-generated by Migen (e2e6c72) & LiteX (f0b5c672) on 2020-03-02 15:51:45
#--------------------------------------------------------------------------------
csr_base,timer0,0x60002800,,
csr_base,fomu_rgb,0x60003000,,
csr_register,timer0_load,0x60002800,4,rw
csr_register,timer0_reload,0x60002810,4,rw
csr_register,timer0_en,0x60002820,1,rw
csr_register,timer0_update_value,0x60002824,1,rw
csr_register,timer0_value,0x60002828,4,ro
csr_register,timer0_ev_status,0x60002838,1,rw
csr_register,timer0_ev_pending,0x6000283c,1,rw
csr_register,timer0_ev_enable,0x60002840,1,rw
csr_register,fomu_rgb_output,0x60003000,1,rw
constant,config_clock_frequency,12000000,,
constant,config_cpu_type,none,,
constant,config_cpu_type_none,None,,
constant,config_csr_alignment,32,,
constant,config_csr_data_width,8,,
constant,config_shadow_base,2147483648,,
memory_region,csr,0x60000000,65536,cached
memory_region,sram,0x10000000,131072,cached

```