### PR TITLE
gdb: wishbone-tool default port is 1234

### DIFF
--- a/docs/riscv.rst
+++ b/docs/riscv.rst
@@ -201,14 +201,14 @@ To start with, run ``wishbone-tool -s gdb``:
 
    $ wishbone-tool -s gdb
    INFO [wishbone_tool::usb_bridge] opened USB device device 008 on bus 001
-   INFO [wishbone_tool::server] accepting connections on 127.0.0.1:3333
+   INFO [wishbone_tool::server] accepting connections on 127.0.0.1:1234
    $
 
 In a second window, run gdb on ``riscv-blink.elf``:
 
 .. session:: shell-session
 
-   $ riscv64-unknown-elf-gdb riscv-blink.elf -ex 'target remote localhost:3333'
+   $ riscv64-unknown-elf-gdb riscv-blink.elf -ex 'target remote localhost:1234'
    GNU gdb (GDB) 8.2.90.20190228-git
    Copyright (C) 2019 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>


### PR DESCRIPTION
wishbone-tool server defaults to 1234:
https://github.com/litex-hub/wishbone-utils/blob/master/wishbone-tool/src/main.rs#L232
```
pdp7@x1:~/dev/fpga/fomu-workshop/riscv-blink$ wishbone-tool -s gdb
INFO [wishbone_tool::bridge::usb] opened USB device device 044 on bus 001
INFO [wishbone_tool::server] accepting connections on 127.0.0.1:1234
```
```
pdp7@x1:~/dev/fpga/fomu-workshop/riscv-blink$ which wishbone-tool
/home/pdp7/dev/fpga/ecp5-toolchain/ecp5-toolchain-linux_x86_64-v1.6.9/bin//wishbone-tool
pdp7@x1:~/dev/fpga/fomu-workshop/riscv-blink$ wishbone-tool --help
Wishbone Tool 0.4.7
Sean Cross <sean@xobs.io>
```