### PR TITLE
Tag documentation sessions with language for better copy'n'paste

### DIFF
--- a/docs/renode-bridge.rst
+++ b/docs/renode-bridge.rst
@@ -47,7 +47,7 @@ You see a new window with a `shell
 application <https://github.com/antmicro/zephyr/commit/29d8e51da15237f2a6bd2a3c8c97e004a66fc97a>`__,
 that provides additional commands allowing you to control LEDs on Fomu.
 
-.. code:: bash
+.. session:: shell-session
 
    uart:~$ led_toggle
    uart:~$ led_breathe

--- a/docs/riscv.rst
+++ b/docs/riscv.rst
@@ -254,7 +254,7 @@ As an alternative to C, the `Rust Language <https://www.rust-lang.org/>`_ can be
 To install Rust, follow the instructions on https://rustup.rs/. After installing Rust, we can install support for RISCV 
 targets using ``rustup``:
 
-.. session::
+.. session:: shell-session
 
      $ rustup target add riscv32i-unknown-none-elf
      info: downloading component 'rust-std' for 'riscv32i-unknown-none-elf'
@@ -264,7 +264,7 @@ targets using ``rustup``:
 A Rust version of the C program used above is located in the ``riscv-rust-blink`` directory. Change into that directory, 
 and build it using ``cargo``, the Rust package manager:
 
-.. session::
+.. session:: shell-session
      
      $ cargo build --release
      Compiling semver-parser v0.7.0
@@ -292,7 +292,7 @@ and build it using ``cargo``, the Rust package manager:
 The resulting binary is located in the target subfolder: ``target/riscv32i-unknown-none-elf/release/riscv-rust-blink``. It can
 be flashed using the ``flash.sh`` script, also located in the ``riscv-rust-blink`` folder:
 
-.. session::
+.. session:: shell-session
 
      $ ./flash.sh
      dfu-suffix (dfu-util) 0.9

--- a/docs/verilog.rst
+++ b/docs/verilog.rst
@@ -15,7 +15,7 @@ Enter the ``verilog/blink-expanded`` directory and build the demo by using ``mak
 **Make sure you set the ``FOMU_REV`` value to match your hardware! See
 the Required Hardware section.**
 
-.. session::
+.. session:: shell-session
 
    $ make FOMU_REV=$FOMU_REV
    ...


### PR DESCRIPTION
The Sphinx `session::` feature can take an optional language marker, which then allows it to parse the example included and generate a more context appropriate copy'n'paste action.  The language marker was missing in some `session::` examples, and there was one `code:: bash` usage left not using session.

For https://github.com/im-tomu/fomu-workshop/issues/144#issuecomment-595993657 change these over to language tagged `session::` examples.