### PR TITLE
Update path to Zephyr

### DIFF
--- a/docs/renode-zephyr.rst
+++ b/docs/renode-zephyr.rst
@@ -68,7 +68,7 @@ You will see the Monitor, where you should type:
 
 ::
 
-   (monitor) $zephyr=@~/zephyrproject/zephyr/build/zephyr/zephyr.elf
+   (monitor) $zephyr=@/path/to/zephyrproject/zephyr/build/zephyr/zephyr.elf
    (monitor) start @scripts/single-node/litex_vexriscv_zephyr.resc
 
 You should see a new window pop up for the serial port. In it, you


### PR DESCRIPTION
With regard to #179, we need to update the path to Zephyr binary in Renode.

It is not copy-paste ready, but now it's evident.

Unfortunately Renode does not have an option to reference $HOME.