### PR TITLE
Add i18n support

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,6 +35,9 @@ env: _download/Miniconda3-latest-Linux-x86_64.sh
 
 .PHONY: env
 
+gettext:
+	@$(SPHINXBUILD) -M gettext "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	mv $(BUILDDIR)/gettext translations/pot
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,6 +37,7 @@ env: _download/Miniconda3-latest-Linux-x86_64.sh
 
 gettext:
 	@$(SPHINXBUILD) -M gettext "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	rm -rf $(BUILDDIR)/gettext/.doctrees
 	mv $(BUILDDIR)/gettext translations/pot
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ version = release
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -280,3 +280,6 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+locale_dirs = ['translations/']   # path is example but recommended.
+gettext_compact = False     # optional.

--- a/docs/translations/pot/background.pot
+++ b/docs/translations/pot/background.pot
@@ -1,0 +1,308 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../background.rst:2
+msgid "Background"
+msgstr ""
+
+#: ../../background.rst:5
+msgid "About FPGAs"
+msgstr ""
+
+#: ../../background.rst:7
+msgid "Field Programmable Gate Arrays (FPGAs) are arrays of gates that are programmable in the field. Unlike most chips you will encounter, which have transistor gates arranged in a fixed order, FPGAs can change their configuration by simply loading new code. Fundamentally, this code programs lookup tables which form the basic building blocks of logic."
+msgstr ""
+
+#: ../../background.rst:13
+msgid "These lookup tables (called LUTs) are so important to the design of an FPGA that they usually form part of the name of the part. For example, Fomu uses a UP5K, which has about 5000 LUTs. NeTV used an LX9, which had about 9000 LUTs, and NeTV2 uses a XC7A35T that has about 35000 LUTs."
+msgstr ""
+
+#: ../../background.rst:22
+msgid "This is the ``SB_LUT4``, which is the basic building block of Fomu. It has four inputs and one output. To program Fomu, we must define what each possible input pattern will create on the output."
+msgstr ""
+
+#: ../../background.rst:26
+msgid "To do this, we turn to a truth table:"
+msgstr ""
+
+#: ../../background.rst:29
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+msgid "0"
+msgstr ""
+
+#: ../../background.rst:29
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:31
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:33
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:35
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+#: ../../background.rst:37
+msgid "1"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "2"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "3"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "4"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "5"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "6"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "7"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "8"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "9"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "10"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "11"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "12"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "13"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "14"
+msgstr ""
+
+#: ../../background.rst:29
+msgid "15"
+msgstr ""
+
+#: ../../background.rst:31
+msgid "IO0"
+msgstr ""
+
+#: ../../background.rst:33
+msgid "IO1"
+msgstr ""
+
+#: ../../background.rst:35
+msgid "IO2"
+msgstr ""
+
+#: ../../background.rst:37
+msgid "IO3"
+msgstr ""
+
+#: ../../background.rst:39
+msgid "O"
+msgstr ""
+
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+#: ../../background.rst:39
+msgid "*?*"
+msgstr ""
+
+#: ../../background.rst:42
+msgid "For example, to create a LUT that acted as an AND gate, we would define O to be 0 for everything except the last column. To create a NAND gate, we would define O to be 1 for everything except the last column."
+msgstr ""
+
+#: ../../background.rst:46
+msgid "FPGA LUTs are almost always *n*-inputs to 1-output. The ICE family of FPGAs from Lattice have 4-input LUTs. Xilinx parts tend to have 5- or 6-input LUTs which generally means they can do more logic in fewer LUTs. Comparing LUT count between FPGAs is a bit like comparing clock speed between different CPUs - not entirely accurate, but certainly a helpful rule of thumb."
+msgstr ""
+
+#: ../../background.rst:53
+msgid "It is from this simple primitive that we build up the building blocks of FPGA design."
+msgstr ""
+
+#: ../../background.rst:57
+msgid "Turning code into gates"
+msgstr ""
+
+#: ../../background.rst:59
+msgid "Writing lookup tables is hard, so people have come up with abstract Hardware Description Languages (HDLs) we can use to describe them. The two most common languages are Verilog and VHDL. In the open source world, Verilog is more common. However, a modern trend is to embed an HDL inside an existing programming language, such as how Migen is embedded in Python, or SpinalHDL is embedded in Scala."
+msgstr ""
+
+#: ../../background.rst:66
+msgid "Here is an example of a Verilog module:"
+msgstr ""
+
+#: ../../background.rst:79
+msgid "We can run this Verilog module through a synthesizer to turn it into ``SB_LUT4`` blocks, or we can turn it into a more familiar logic diagram:"
+msgstr ""
+
+#: ../../background.rst:87
+msgid "If we do decide to synthesize to ``SB_LUT4`` blocks, we will end up with a pile of LUTs that need to be strung together somehow. This is done by a Place-and-Route tool. This performs the job of assigning physical LUTs to each LUT that gets defined by the synthesizer, and then figuring out how to wire it all up."
+msgstr ""
+
+#: ../../background.rst:93
+msgid "Once the place-and-route tool is done, it generates an abstract file that needs to be translated into a format that the hardware can recognize. This is done by a bitstream packing tool. Finally, this bitstream needs to be loaded onto the device somehow, either off of a SPI flash or by manually programming it by toggling wires."
+msgstr ""
+
+#: ../../background.rst:100
+msgid "About the ICE40UP5K"
+msgstr ""
+
+#: ../../background.rst:102
+msgid "We will use an ICE40UP5K for this workshop. This chip has a number of very nice features:"
+msgstr ""
+
+#: ../../background.rst:105
+msgid "5280 4-input LUTs (LC)"
+msgstr ""
+
+#: ../../background.rst:106
+msgid "16 kilobytes BRAM"
+msgstr ""
+
+#: ../../background.rst:107
+msgid "**128 kilobytes “SPRAM”**"
+msgstr ""
+
+#: ../../background.rst:108
+msgid "Current-limited 3-channel LED driver"
+msgstr ""
+
+#: ../../background.rst:109
+msgid "2x I2C and 2x SPI"
+msgstr ""
+
+#: ../../background.rst:110
+msgid "8 16-bit DSP units"
+msgstr ""
+
+#: ../../background.rst:111
+msgid "**Warmboot capability**"
+msgstr ""
+
+#: ../../background.rst:112
+msgid "**Open toolchain**"
+msgstr ""
+
+#: ../../background.rst:114
+msgid "Many FPGAs have what’s called block RAM, or BRAM. This is frequently used to store data such as buffers, CPU register files, and large arrays of data. This type of memory is frequently reused as RAM on many FPGAs. The ICE40UP5K is unusual in that it also as 128 kilobytes of Single Ported RAM that can be used as memory for a softcore (a term used for a CPU core running inside an FPGA, to differentiate it from a ‘hard’ - i.e. fixed chip - implementation). That means that, unlike other FPGAs, valuable block RAM isn’t taken up by system memory."
+msgstr ""
+
+#: ../../background.rst:123
+msgid "Additionally, the ICE40 family of devices generally supports “warmboot” capability. This enables us to have multiple designs live on the same FPGA and tell the FPGA to swap between them."
+msgstr ""
+
+#: ../../background.rst:127
+msgid "As always, this workshop wouldn’t be nearly as easy without the open toolchain that enables us to port it to a lot of different platforms."
+msgstr ""
+
+#: ../../background.rst:131
+msgid "About Fomu"
+msgstr ""
+
+#: ../../background.rst:133
+msgid "Fomu is an ICE40UP5K that fits in your USB port. It contains two megabytes of SPI flash memory, four edge buttons, and a three-color LED. Unlike most other ICE40 projects, Fomu implements its USB in a softcore. That means that the bitstream that runs on the FPGA must also provide the ability to communicate over USB. This uses up a lot of storage on this small FPGA, but it also enables us to have such a tiny form factor, and lets us do some really cool things with it."
+msgstr ""
+
+#: ../../background.rst:145
+msgid "The ICE40UP5K at the heart of Fomu really controls everything, and this workshop is all about trying to unlock the power of this chip."
+msgstr ""

--- a/docs/translations/pot/bootloader.pot
+++ b/docs/translations/pot/bootloader.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../bootloader.rst:4
+msgid "Bootloader"
+msgstr ""
+
+#: ../../bootloader.rst:10
+msgid "Updating the Fomu Bootloader"
+msgstr ""
+
+#: ../../bootloader.rst:13
+msgid "To update your Fomu, download the appropriate ``-updater`` dfu release from `foboot <https://github.com/im-tomu/foboot/releases/latest>`__."
+msgstr ""
+
+#: ../../bootloader.rst:16
+msgid "Download the :file:`{board type}-updater-v2.0.3.dfu` file."
+msgstr ""
+
+#: ../../bootloader.rst:18
+msgid "If you have a ``PVT`` Fomu, download |pvt-updater|."
+msgstr ""
+
+#: ../../bootloader.rst:19
+msgid "If you have a ``Hacker`` Fomu, download |hacker-updater|."
+msgstr ""
+
+#: ../../bootloader.rst:21
+msgid "Run :file:`dfu-util -D pvt-updater-{version}.dfu`."
+msgstr ""
+
+#: ../../bootloader.rst:22
+msgid "Your Fomu will flash rainbow for about five seconds, then reboot and go back to blinking."
+msgstr ""
+
+#: ../../bootloader.rst:24
+msgid "To verify it has updated, ``dfu-util -l`` and check the version output."
+msgstr ""
+
+#: ../../bootloader.rst:29
+msgid "This is an example session for updating a production board:"
+msgstr ""

--- a/docs/translations/pot/hdl.pot
+++ b/docs/translations/pot/hdl.pot
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../hdl.rst:2
+msgid "Hardware Description Languages"
+msgstr ""
+
+#: ../../hdl.rst:4
+msgid "The two most common **H**\\ ardware **D**\\ escription **L**\\ anguages are Verilog and VHDL (the toolchain we are using only supports Verilog)."
+msgstr ""

--- a/docs/translations/pot/help.pot
+++ b/docs/translations/pot/help.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../help.rst:2
+msgid "Getting Help"
+msgstr ""
+
+#: ../../help.rst:4
+msgid "If you get stuck anywhere in the workshop you can use the following channels to get help!"
+msgstr ""
+
+#: ../../help.rst:8
+msgid "IRC Chat Channel"
+msgstr ""
+
+#: ../../help.rst:10
+msgid "IRC (`Internet Relay Chat <https://en.wikipedia.org/wiki/Internet_Relay_Chat>`__) is old school chat before Slack became popular. You can connect with a wide range of different clients including web based clients like `IRCCloud <https://irccloud.com>`__."
+msgstr ""
+
+#: ../../help.rst:15
+msgid "`#tomu channel on irc.freenode.net <irc://irc.freenode.net/#tomu>`__"
+msgstr ""
+
+#: ../../help.rst:16
+msgid "`Freenode WebChat <https://webchat.freenode.net/?channels=#tomu>`__"
+msgstr ""
+
+#: ../../help.rst:17
+msgid "`Channel Logs <https://logs.timvideos.us/%23tomu/>`__ - `Latest <https://logs.timvideos.us/%23tomu/latest.log.html>`__"
+msgstr ""
+
+#: ../../help.rst:20
+msgid "Mailing Lists"
+msgstr ""
+
+#: ../../help.rst:22
+msgid "`Announcement mailing list <https://groups.google.com/forum/#!forum/tomu-announce/join>`__ - Low traffic list for announcements."
+msgstr ""
+
+#: ../../help.rst:23
+msgid "`Discussion mailing list <https://groups.google.com/forum/#!forum/tomu-discuss/join>`__ - List for discussing development / new features / etc."
+msgstr ""

--- a/docs/translations/pot/index.pot
+++ b/docs/translations/pot/index.pot
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../index.rst:3
+msgid "FPGA Tomu Workshop"
+msgstr ""
+
+#: ../../index.rst:8
+msgid "Hi, I’m Fomu! This workshop covers the basics of Fomu in a top-down approach. We’ll start out by learning what Fomu is, how to load software into Fomu, and finally how to write software for Fomu."
+msgstr ""
+
+#: ../../index.rst:12
+msgid "FPGAs are complex, weird things, so we’ll take a gentle approach and start out by treating it like a Python interpreter first, and gradually peel away layers until we’re writing our own hardware registers. You can take a break at any time and explore! Stop when you feel the concepts are too unfamiliar, or plough on and dig deep into the world of hardware."
+msgstr ""
+
+#: ../../index.rst:20
+msgid "Table of Contents"
+msgstr ""

--- a/docs/translations/pot/migen.pot
+++ b/docs/translations/pot/migen.pot
@@ -1,0 +1,105 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../migen.rst:2
+msgid "Migen and LiteX"
+msgstr ""
+
+#: ../../migen.rst:7
+msgid "“Hello world!” - Blink a LED"
+msgstr ""
+
+#: ../../migen.rst:9
+msgid "Migen is an HDL embedded in Python. The verilog examples (in directory ``verilog``) can also be written using Migen; an implementation is provided in directory ``migen``."
+msgstr ""
+
+#: ../../migen.rst:13
+msgid "To try them out, go to the ``migen`` directory and execute ``blink.py`` or ``blink-expanded.py`` respectively (before, ensure that you have set the ``FOMU_REV`` environment variable correctly). This will create a ``build`` directory with a ``top.bin`` file."
+msgstr ""
+
+#: ../../migen.rst:18
+msgid "Using ``dfu-util -D build/top.bin``, it can be loaded onto the Fomu and should work identically as the corresponding verilog example."
+msgstr ""
+
+#: ../../migen.rst:22
+msgid "Wishbone Bus Basics"
+msgstr ""
+
+#: ../../migen.rst:24
+msgid "LiteX provides us with a Wishbone abstraction layer. There really is no reason we need to include a CPU with our design, but we can still reuse the USB Wishbone bridge in order to write HDL code."
+msgstr ""
+
+#: ../../migen.rst:28
+msgid "We can use ``DummyUsb`` to respond to USB requests and bridge USB to Wishbone, and rely on LiteX to generate registers and wire them to hardware signals. We can still use ``wishbone-tool`` to read and write memory, and with a wishbone bridge we can actually have code running on our local system that can read and write memory on Fomu."
+msgstr ""
+
+#: ../../migen.rst:34
+msgid "Go to the ``litex`` directory and build the design;"
+msgstr ""
+
+#: ../../migen.rst:72
+msgid "Load it onto Fomu:"
+msgstr ""
+
+#: ../../migen.rst:100
+msgid "If you get an error message about missing modules, check you have all submodules cloned and setup with;"
+msgstr ""
+
+#: ../../migen.rst:108
+msgid "Take a look at ``build/csr.csv``. This describes the various regions present in our design. You can see ``memory_region,sram,0x10000000,131072``, which indicates the RAM is 128 kilobytes long and is located at ``0x10000000``, just as when we had a CPU. You can also see the timer, which is a feature that comes as part of LiteX. Let’s try reading and writing RAM:"
+msgstr ""
+
+#: ../../migen.rst:125
+msgid "Wishbone Bus Extension"
+msgstr ""
+
+#: ../../migen.rst:127
+msgid "Aside from that, there’s not much we can *do* with this design. But there’s a lot of infrastructure there. So let’s add something we can see (``workshop_rgb.py`` contains the completed example)."
+msgstr ""
+
+#: ../../migen.rst:135
+msgid "This is the RGB block from the datasheet. It has five inputs: ``CURREN``, ``RGBLEDEN``, ``RGB0PWM``, ``RGB1PWM``, and ``RGB2PWM``. It has three outputs: ``RGB0``, ``RGB1``, and ``RGB2``. It also has four parameters: ``CURRENT_MODE``, ``RGB0_CURRENT``, ``RGB1_CURRENT``, and ``RGB2_CURRENT``."
+msgstr ""
+
+#: ../../migen.rst:141
+msgid "This block is defined in Verilog (as ``SB_RGBA_DRV``), but we can import it as a Module into Migen:"
+msgstr ""
+
+#: ../../migen.rst:164
+msgid "This will instantiate this Verilog block and connect it up. It also creates a ``CSRStorage`` object that is three bits wide, and assigns it to ``output``. By having this derive from ``AutoCSR``, the CSRStorage will have CSR bus accessor methods added to it automatically. Finally, it wires the pads up to the outputs of the block."
+msgstr ""
+
+#: ../../migen.rst:170
+msgid "We can instantiate this block by simply creating a new object and adding it to ``self.specials`` in our design:"
+msgstr ""
+
+#: ../../migen.rst:180
+msgid "Finally, we need to add it to the ``csr_map``:"
+msgstr ""
+
+#: ../../migen.rst:187
+msgid "Now, when we rebuild this design and check ``build/csr.csv`` we can see our new register:"
+msgstr ""
+
+#: ../../migen.rst:194
+msgid "We can use ``wishbone-tool`` to write values to ``0x60003000`` (or whatever your ``build/csr.csv`` says) and see them take effect immediately."
+msgstr ""
+
+#: ../../migen.rst:207
+msgid "You can see that it takes very little code to take a Signal from HDL and expose it on the Wishbone bus."
+msgstr ""

--- a/docs/translations/pot/python.pot
+++ b/docs/translations/pot/python.pot
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../python.rst:2
+msgid "Python on Fomu"
+msgstr ""
+
+#: ../../python.rst:4
+msgid "You can load `MicroPython <https://micropython.org/>`__, a small Python implementation, onto Fomu as an ordinary RISC-V binary. A precompiled binary is located in the root of the Fomu workshop files."
+msgstr ""
+
+#: ../../python.rst:8
+msgid "Use ``dfu-util`` to load it:"
+msgstr ""
+
+#: ../../python.rst:34
+msgid "If you’re on a macOS machine, use the following command to connect to the device:"
+msgstr ""
+
+#: ../../python.rst:43
+msgid "If you’re on Linux, use the following command to connect to the device, it will be called ``ttyACM?``:"
+msgstr ""
+
+#: ../../python.rst:52
+msgid "If you’re running a version of Windows earlier than Windows 10, you will need to install a driver for the serial port. Open Zadag again and select ``Fomu`` from the dropdown list. Install the driver for ``USB Serial (CDC)``."
+msgstr ""
+
+#: ../../python.rst:57
+msgid "You can then use a program such as `Tera Term <https://tera-term.en.lo4d.com/download>`__."
+msgstr ""
+
+#: ../../python.rst:64
+msgid "In Teraterm hit ``New Connection`` and select the ``Serial Port`` Radio Button. If it is greyed out you might have to change your USB Port driver for the Fomu."
+msgstr ""
+
+#: ../../python.rst:68
+msgid "See `Working with Fomu <#working-with-fomu>`__, above."
+msgstr ""
+
+#: ../../python.rst:71
+msgid "You should be greeted with a MicroPython banner and REPL:"
+msgstr ""
+
+#: ../../python.rst:78
+msgid "This is a fully-functioning MicroPython shell. Try running some simple commands such as ``print()`` and ``hex(9876+1234)``."
+msgstr ""
+
+#: ../../python.rst:82
+msgid "Fomu Python Extensions"
+msgstr ""
+
+#: ../../python.rst:84
+msgid "Fomu’s MicroPython binary contains a few extended Python modules that you can use to interact with some of the hardware. For example, the RGB LED has some predefined modes you can access. These are all located under the ``fomu`` module."
+msgstr ""
+
+#: ../../python.rst:89
+msgid "Import the ``fomu`` module and access the ``rgb`` block to change the mode to the predefined ``error`` mode:"
+msgstr ""
+
+#: ../../python.rst:99
+msgid "We can also look at some information from the SPI flash, such as the SPI ID. This ID varies between Fomu models, so it can be a good indication of what kind of Fomu your code is running on:"
+msgstr ""
+
+#: ../../python.rst:111
+msgid "Memory-mapped Registers"
+msgstr ""
+
+#: ../../python.rst:113
+msgid "If we look at the generated Fomu header files (to be found for instance in `riscv-blink <_static/riscv-blink/include/generated/csr.h>`__), we can see many, many memory-mapped registers. For example, the major, minor, and revision numbers all have registers:"
+msgstr ""
+
+#: ../../python.rst:125
+msgid "These are special areas of memory that don’t really exist. Instead, they correspond to hardware. We can read these values using the ``machine`` class. Read out the major, minor, and revision codes from your Fomu. They may be different from what you see here:"
+msgstr ""
+
+#: ../../python.rst:141
+msgid "The ``CSR_VERSION_MODEL_ADDR`` contains a single character that indicates what version of the hardware you have. We can convert this to a character and print it out."
+msgstr ""
+
+#: ../../python.rst:145
+msgid "If you have a production board you will get ``P`` as shown below;"
+msgstr ""
+
+#: ../../python.rst:153
+msgid "If you have a hacker board you will get ``H`` as shown below;"
+msgstr ""
+
+#: ../../python.rst:162
+msgid "Memory-mapped RGB driver"
+msgstr ""
+
+#: ../../python.rst:164
+msgid "The blinking LED is actually a hardware block from Lattice. It has control registers, and we can modify these registers by writing to memory in Fomu. Some of these registers control things such as the timing of the fade in and fade out pulses, and some control the level of each of the three colors."
+msgstr ""
+
+#: ../../python.rst:174
+msgid "There is a wrapper in Fomu’s MicroPython that simplifies the process of writing to these registers. The first argument is the register number, and the second argument is the value to write."
+msgstr ""
+
+#: ../../python.rst:178
+msgid "For the ``LEDDPWR`` registers, the second argument determines the brightness, value ranges from 0 to 255."
+msgstr ""
+
+#: ../../python.rst:181
+msgid "Try changing the color of the three LEDs:"
+msgstr ""
+
+#: ../../python.rst:193
+msgid "The color should change immediately. More information on these registers can be found in the `ICE40 LED Driver Usage Guide <_static/reference/FPGA-TN-1288-ICE40LEDDriverUsageGuide.pdf>`__."
+msgstr ""

--- a/docs/translations/pot/renode-bridge.pot
+++ b/docs/translations/pot/renode-bridge.pot
@@ -1,0 +1,89 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../renode-bridge.rst:2
+msgid "Wishbone bridge between Renode and Fomu"
+msgstr ""
+
+#: ../../renode-bridge.rst:4
+msgid "This part of the workshop is based on a `Renode, Fomu and Etherbone bridge example <https://renode.readthedocs.io/en/latest/tutorials/fomu-example.html>`__ from the Renode documentation."
+msgstr ""
+
+#: ../../renode-bridge.rst:9
+msgid "Just like we can access Fomu peripherals using ``wishbone-tool``, we can also connect to a physical board from Renode, mapping a part of the memory space to be accessible via the Etherbone protocol."
+msgstr ""
+
+#: ../../renode-bridge.rst:13
+msgid "This is a very useful capability as it enables us to potentially simulate an advanced LiteX SoC system which would not normally fit in the FPGA (or e.g. take a long time to synthesize), and interface it with the remaining part of the physical system for I/O."
+msgstr ""
+
+#: ../../renode-bridge.rst:19
+msgid "Setting up the server"
+msgstr ""
+
+#: ../../renode-bridge.rst:21
+msgid "You can use ``wishbone-tool`` to bridge protocols such as USB to Etherbone. To start the server, run the following command:"
+msgstr ""
+
+#: ../../renode-bridge.rst:29
+msgid "This starts an Etherbone server on ``localhost:1234`` by default.  See ``wishbone-tool --help`` to change these settings."
+msgstr ""
+
+#: ../../renode-bridge.rst:32
+msgid "Now you can start Renode and setup the platform."
+msgstr ""
+
+#: ../../renode-bridge.rst:35
+msgid "Connecting from Renode"
+msgstr ""
+
+#: ../../renode-bridge.rst:37
+msgid "Run ``renode`` and in the Monitor type:"
+msgstr ""
+
+#: ../../renode-bridge.rst:46
+msgid "You see a new window with a `shell application <https://github.com/antmicro/zephyr/commit/29d8e51da15237f2a6bd2a3c8c97e004a66fc97a>`__, that provides additional commands allowing you to control LEDs on Fomu."
+msgstr ""
+
+#: ../../renode-bridge.rst:55
+msgid "The ``led_toggle`` command controls the LED by turning it on and off. ``led_breathe`` makes the LED fade slowly in and out, creating a “breathe” effect."
+msgstr ""
+
+#: ../../renode-bridge.rst:59
+msgid "The script you loaded configures Renode to log all communication with Fomu. After issuing some commands in Zephyr’s shell you’ll see:"
+msgstr ""
+
+#: ../../renode-bridge.rst:86
+msgid "You can interact with Fomu manually, via the Monitor. To do that, you first need to find the name of the peripheral that serves the connection to Fomu."
+msgstr ""
+
+#: ../../renode-bridge.rst:90
+msgid "Type in ``peripherals`` to see a list of all the elements of the emulated SoC. Look for ``EtherBoneBridge`` entry:"
+msgstr ""
+
+#: ../../renode-bridge.rst:146
+msgid "The device that acts as a connector to Fomu is called ``led`` and is registered at ``0xE0006800``:"
+msgstr ""
+
+#: ../../renode-bridge.rst:154
+msgid "You can either use a full or relative address (via the ``sysbus`` or ``led`` objects, respectively) to communicate with the physical LED controller:"
+msgstr ""
+
+#: ../../renode-bridge.rst:163
+msgid "Note: the above values are just an example and won’t change the LED status in any visible way. If you want to enable “breathe” effect directly from the Monitor, see the necessary sequence in `the application source code <https://github.com/antmicro/zephyr/commit/29d8e51da15237f2a6bd2a3c8c97e004a66fc97a>`__."
+msgstr ""

--- a/docs/translations/pot/renode-starting.pot
+++ b/docs/translations/pot/renode-starting.pot
@@ -1,0 +1,81 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../renode-starting.rst:2
+msgid "Getting Renode"
+msgstr ""
+
+#: ../../renode-starting.rst:4
+msgid "Renode is available for Linux, macOS and Windows."
+msgstr ""
+
+#: ../../renode-starting.rst:6
+msgid "On Linux and macOS, you need to have `Mono <https://www.mono-project.com>`__ installed on your computer. You should follow the `Mono installation instructions <https://www.mono-project.com/download/stable/>`__ and install the ``mono-complete`` package."
+msgstr ""
+
+#: ../../renode-starting.rst:12
+msgid "On Windows it’s enough to have a fairly recent `.NET Framework <https://dotnet.microsoft.com/download/dotnet-framework>`__ installed."
+msgstr ""
+
+#: ../../renode-starting.rst:16
+msgid "Then you can either install Renode from `prebuilt packages <https://github.com/renode/renode#installation>`__, or `compile it yourself <https://renode.readthedocs.io/en/latest/advanced/building_from_sources.html>`__."
+msgstr ""
+
+#: ../../renode-starting.rst:22
+msgid "Try out Renode quickly with precompiled LiteX demos"
+msgstr ""
+
+#: ../../renode-starting.rst:24
+msgid "Renode comes with several precompiled demos, which can be used to verify everything works for you before starting to compile and use your own software binaries."
+msgstr ""
+
+#: ../../renode-starting.rst:28
+msgid "There are three demo scripts available:"
+msgstr ""
+
+#: ../../renode-starting.rst:30
+msgid "``litex_vexriscv_micropython.resc``"
+msgstr ""
+
+#: ../../renode-starting.rst:31
+msgid "``litex_vexriscv_zephyr.resc``"
+msgstr ""
+
+#: ../../renode-starting.rst:32
+msgid "``litex_vexriscv_linux.resc``"
+msgstr ""
+
+#: ../../renode-starting.rst:34
+msgid "To run them, start Renode using the ``renode`` command (or ``./renode`` if you built from sources)."
+msgstr ""
+
+#: ../../renode-starting.rst:37
+msgid "You will see a terminal window pop up, which is the Renode CLI, called the Monitor."
+msgstr ""
+
+#: ../../renode-starting.rst:40
+msgid "In the Monitor type:"
+msgstr ""
+
+#: ../../renode-starting.rst:46
+msgid "(where is one of the above)."
+msgstr ""
+
+#: ../../renode-starting.rst:48
+msgid "Voila! A UART analyzer window should appear and you should see LiteX booting the respective binary."
+msgstr ""

--- a/docs/translations/pot/renode-verilator.pot
+++ b/docs/translations/pot/renode-verilator.pot
@@ -1,0 +1,105 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../renode-verilator.rst:2
+msgid "Renode Co-simulation using Verilator"
+msgstr ""
+
+#: ../../renode-verilator.rst:4
+msgid "While connecting Renode to a real FPGA gives you some interesting possibilities in testing and debugging your gateware together with your software, there is another usage scenario which is completely hardware independent - connecting functional simulation of the base system in Renode with HDL simulation of a part of the system that is under development."
+msgstr ""
+
+#: ../../renode-verilator.rst:11
+msgid "To this end, Renode provides an integration layer for Verilator. A typical setup with Renode + Verilator consists of several components:"
+msgstr ""
+
+#: ../../renode-verilator.rst:14
+msgid "the ‘verilated’ HDL code itself (e.g. a UART peripheral),"
+msgstr ""
+
+#: ../../renode-verilator.rst:15
+msgid "Verilator integration library, `provided as a plugin to Renode <https://github.com/renode/renode/tree/master/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src>`__,"
+msgstr ""
+
+#: ../../renode-verilator.rst:17
+msgid "shim layer in C++ connecting the above."
+msgstr ""
+
+#: ../../renode-verilator.rst:19
+msgid "Currently Renode supports peripherals with the AXILite interface. Keep in mind that due to the abstract nature of bus operations in Renode, it doesn’t matter what kind of bus is used on the hardware you want to simulate."
+msgstr ""
+
+#: ../../renode-verilator.rst:24
+msgid "In the Renode tree you will find an example with all the elements already prepared. To run it, start Renode and type:"
+msgstr ""
+
+#: ../../renode-verilator.rst:32
+msgid "This script loads a RISC-V-based system with a verilated UARTLite. You can verify it by calling:"
+msgstr ""
+
+#: ../../renode-verilator.rst:40
+msgid "To inspect the communication with the UART, run:"
+msgstr ""
+
+#: ../../renode-verilator.rst:46
+msgid "You will see every read and write to the peripheral displayed in the Renode log."
+msgstr ""
+
+#: ../../renode-verilator.rst:49
+msgid "Please note that, despite not being a Renode-native model, the UART is also capable of displaying an analyzer window. This is because Renode adds a special support for UART-type peripherals, allowing you not only to connect bus lines, but also the TX and RX UART lines, to the Renode infrastructure."
+msgstr ""
+
+#: ../../renode-verilator.rst:55
+msgid "The HDL and integration layer for this UART peripheral is available on `Antmicro’s GitHub <https://github.com/antmicro/renode-verilator-integration/tree/master/samples/uartlite>`__."
+msgstr ""
+
+#: ../../renode-verilator.rst:59
+msgid "To compile it manually, you need to have ``ZeroMQ`` (``libzmq3-dev`` on Debian-like systems) and ``Verilator`` installed in your system. You also need to provide a full path to the ``src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary`` directory as the ``INTEGRATION_DIR`` environment variable. This means that you need to have a copy of Renode sources to build a verilated peripheral."
+msgstr ""
+
+#: ../../renode-verilator.rst:66
+msgid "With this set up, simply run ``make``."
+msgstr ""
+
+#: ../../renode-verilator.rst:69
+msgid "Integration with verilated code"
+msgstr ""
+
+#: ../../renode-verilator.rst:71
+msgid "Renode supports integration with Verilator via AXILite bus, but can be easily expanded to support other standards as well."
+msgstr ""
+
+#: ../../renode-verilator.rst:74
+msgid "We’ll briefly take a look on the integration layer implemented in `sim-main.cpp <https://github.com/antmicro/renode-verilator-integration/blob/master/samples/uartlite/sim_main.cpp>`__."
+msgstr ""
+
+#: ../../renode-verilator.rst:77
+msgid "First, the user has to decide on the bus type and peripheral type. These are provided by the integration library:"
+msgstr ""
+
+#: ../../renode-verilator.rst:85
+msgid "A bus is a type declaring all the signals and how should they be handled on each transaction. These signals have to be connected to the signals in the HDL design:"
+msgstr ""
+
+#: ../../renode-verilator.rst:111
+msgid "To handle the “external” communication, the user can either use the base ``RenodeAgent`` class of one of its derivatives: for example the ``UART`` type allows you to connect RX and TX signals:"
+msgstr ""
+
+#: ../../renode-verilator.rst:121
+msgid "For more details, see the `verilated uartlite repository <https://github.com/antmicro/renode-verilator-integration/tree/master/samples/uartlite>`__."
+msgstr ""

--- a/docs/translations/pot/renode-zephyr.pot
+++ b/docs/translations/pot/renode-zephyr.pot
@@ -1,0 +1,85 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../renode-zephyr.rst:2
+msgid "Running your own Zephyr binary on LiteX/VexRiscv in Renode"
+msgstr ""
+
+#: ../../renode-zephyr.rst:4
+msgid "Zephyr is a very capable RTOS governed by a Linux Foundation subproject. It is very well supported on the RISC-V architecture, as well as in LiteX."
+msgstr ""
+
+#: ../../renode-zephyr.rst:9
+msgid "Building a Zephyr application"
+msgstr ""
+
+#: ../../renode-zephyr.rst:11
+msgid "To install all the dependencies and prepare the environment for building the Zephyr application follow the official `Zephyr Getting Started Guide <https://docs.zephyrproject.org/latest/getting_started/index.html>`__ up to point 4. On Linux you can follow the instructions from the point 5 on installing the Software Development Toolchain. The python version in the FOMU toolchain may not work; remove it from your PATH before attempting to build zephyr. For other operating systems, if you followed the instructions from the ``Required Software`` section of this tutorial, you should have a toolchain in ``PATH``."
+msgstr ""
+
+#: ../../renode-zephyr.rst:22
+msgid "On macOS and Windows you also need to set some additional variables."
+msgstr ""
+
+#: ../../renode-zephyr.rst:24
+msgid "For macOS:"
+msgstr ""
+
+#: ../../renode-zephyr.rst:31
+msgid "For Windows:"
+msgstr ""
+
+#: ../../renode-zephyr.rst:38
+msgid "To build the ``shell`` demo application for the LiteX/VexRiscv board run the following commands on Linux and macOS:"
+msgstr ""
+
+#: ../../renode-zephyr.rst:47
+msgid "And on Windows:"
+msgstr ""
+
+#: ../../renode-zephyr.rst:55
+msgid "The resulting ELF file will be in ``build/zephyr/zephyr.elf``."
+msgstr ""
+
+#: ../../renode-zephyr.rst:58
+msgid "Run the app in Renode"
+msgstr ""
+
+#: ../../renode-zephyr.rst:60
+msgid "To run the app you just compiled, you basically need to replace the precomipled demo binary with the one you want, by setting the ``zephyr`` variable - see below."
+msgstr ""
+
+#: ../../renode-zephyr.rst:64
+msgid "Just like before, start Renode using the ``renode`` command (or ``./renode`` if you built from sources)."
+msgstr ""
+
+#: ../../renode-zephyr.rst:67
+msgid "You will see the Monitor, where you should type:"
+msgstr ""
+
+#: ../../renode-zephyr.rst:74
+msgid "You should see a new window pop up for the serial port. In it, you should see the Zephyr interactive shell."
+msgstr ""
+
+#: ../../renode-zephyr.rst:78
+msgid "Debugging the app in Renode"
+msgstr ""
+
+#: ../../renode-zephyr.rst:80
+msgid "In general, debugging in Renode is done with GDB just like with a physical board - you connect to a debug port and execute GDB commands as usual. For details, see the `Renode debugging documentation <https://renode.readthedocs.io/en/latest/debugging/gdb.html>`__."
+msgstr ""

--- a/docs/translations/pot/renode.pot
+++ b/docs/translations/pot/renode.pot
@@ -1,0 +1,41 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../renode.rst:2
+msgid "Working with LiteX and (co-)simulation with Renode"
+msgstr ""
+
+#: ../../renode.rst:4
+msgid "LiteX used as the soft SoC on Fomu is a very robust and scalable soft SoC platform, capable of running both bare metal binaries, Zephyr and even Linux."
+msgstr ""
+
+#: ../../renode.rst:8
+msgid "It is also supported in `Renode <https://renode.io>`__, which is an open source simulation framework that lets you run unmodified software in a fully controlled and inspectable environment. Renode is a functional simulator, which means it aims to mimic the observable behavior of the hardware instead of trying to be cycle-accurate."
+msgstr ""
+
+#: ../../renode.rst:14
+msgid "We will now see how a full-blown Zephyr RTOS can be run on LiteX in Renode, and then how this simulation can be interfaced with a Fomu for a useful HW/SW co-development workflow."
+msgstr ""
+
+#: ../../renode.rst:19
+msgid "Apart from RISC-V and LiteX platforms, Renode supports many other architectures and platforms, as described in the `documentation <https://renode.readthedocs.io/en/latest/introduction/supported-boards.html>`__, which also includes a user manual and a few tutorials. You can also take a look at a `Video Tutorials section on Renode’s website <https://renode.io/tutorials/>`__."
+msgstr ""
+
+#: ../../renode.rst:26
+msgid "Keep in mind that all platforms and configurations in Renode used in this tutorial are contained in text/config files - you can also explore Renode’s usage patterns by just inspecting those files for details."
+msgstr ""

--- a/docs/translations/pot/requirements.pot
+++ b/docs/translations/pot/requirements.pot
@@ -1,0 +1,457 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../requirements.rst:4
+msgid "Requirements"
+msgstr ""
+
+#: ../../requirements.rst:6
+msgid "For this workshop you will need;"
+msgstr ""
+
+#: ../../requirements.rst:8
+msgid "The Fomu workshop files - see :ref:`required-files` section."
+msgstr ""
+
+#: ../../requirements.rst:9
+msgid "The Fomu toolchain - see :ref:`required-software` section."
+msgstr ""
+
+#: ../../requirements.rst:10
+msgid "A Fomu board - see :ref:`required-hardware` section."
+msgstr ""
+
+#: ../../requirements.rst:11
+msgid "Set up drivers - see :ref:`required-drivers` section."
+msgstr ""
+
+#: ../../requirements.rst:15
+msgid "If you are at a workshop, please **install the tools first** and then get the hardware from your presenter."
+msgstr ""
+
+#: ../../requirements.rst:21
+msgid "Your Fomu should be running Foboot |Foboot Version| or newer."
+msgstr ""
+
+#: ../../requirements.rst:23
+msgid "You can see what version you are running by typing ``dfu-util -l`` like so;"
+msgstr ""
+
+#: ../../requirements.rst:39
+msgid "If your Fomu is running an version older than |Foboot Version| follow the :ref:`bootloader-update` section."
+msgstr ""
+
+#: ../../requirements.rst:45
+msgid "Required Files"
+msgstr ""
+
+#: ../../requirements.rst:47
+msgid "You will need the Workshop files. They are located in the `fomu-workshop <https://github.com/im-tomu/fomu-workshop>`__ Github repository. You can download `master.zip <https://github.com/im-tomu/fomu-workshop/archive/master.zip>`__ or clone it from git:"
+msgstr ""
+
+#: ../../requirements.rst:87
+msgid "If you’re attending a workshop that provides USB drives, these files may be available on the USB drive under the ``Workshop`` directory."
+msgstr ""
+
+#: ../../requirements.rst:93
+msgid "Required Software"
+msgstr ""
+
+#: ../../requirements.rst:95
+msgid "Fomu requires specialized software. This software is provided for Linux x86/64, macOS, and Windows, via `Fomu Toolchain <https://github.com/im-tomu/fomu-toolchain/releases/latest>`__."
+msgstr ""
+
+#: ../../requirements.rst:99
+msgid "Debian packages are also `available for Raspberry Pi <https://github.com/im-tomu/fomu-raspbian-packages>`__."
+msgstr ""
+
+#: ../../requirements.rst:102
+msgid "If you’re taking this workshop as a class, the toolchains are provided on the USB disk."
+msgstr ""
+
+#: ../../requirements.rst:105
+msgid "To install the software, extract it somewhere on your computer, then open up a terminal window and add that directory to your PATH:"
+msgstr ""
+
+#: ../../requirements.rst:124
+msgid "If you use PowerShell as your terminal;"
+msgstr ""
+
+#: ../../requirements.rst:130
+msgid "If you use ``cmd.exe`` as your terminal;"
+msgstr ""
+
+#: ../../requirements.rst:136
+msgid "To confirm installation, run the ``yosys`` command and confirm you get the following output;"
+msgstr ""
+
+#: ../../requirements.rst:168
+msgid "Ensure it says **(Fomu build)**. Type ``exit`` to quit ``yosys``."
+msgstr ""
+
+#: ../../requirements.rst:172
+msgid "The `Fomu Toolchain <https://github.com/im-tomu/fomu-toolchain/releases/latest>`__ consists of the following tools;"
+msgstr ""
+
+#: ../../requirements.rst:176
+msgid "Tool"
+msgstr ""
+
+#: ../../requirements.rst:176
+msgid "Purpose"
+msgstr ""
+
+#: ../../requirements.rst:178
+msgid "`yosys <https://github.com/YosysHQ/yosys>`__"
+msgstr ""
+
+#: ../../requirements.rst:178
+msgid "Verilog synthesis"
+msgstr ""
+
+#: ../../requirements.rst:179
+msgid "`nextpnr-ice40 <https://github.com/YosysHQ/nextpnr>`__"
+msgstr ""
+
+#: ../../requirements.rst:179
+msgid "FPGA place-and-route"
+msgstr ""
+
+#: ../../requirements.rst:180
+msgid "`icestorm <https://github.com/cliffordwolf/icestorm>`__"
+msgstr ""
+
+#: ../../requirements.rst:180
+msgid "FPGA bitstream packing"
+msgstr ""
+
+#: ../../requirements.rst:181
+msgid "`riscv toolchain <https://www.sifive.com/boards/>`__"
+msgstr ""
+
+#: ../../requirements.rst:181
+msgid "Compile code for a RISC-V softcore"
+msgstr ""
+
+#: ../../requirements.rst:182
+msgid "`dfu-util <https://dfu-util.sourceforge.net/>`__"
+msgstr ""
+
+#: ../../requirements.rst:182
+msgid "Load a bitstream or code onto Fomu"
+msgstr ""
+
+#: ../../requirements.rst:183
+msgid "`python <https://python.org/>`__"
+msgstr ""
+
+#: ../../requirements.rst:183
+msgid "Convert Migen/Litex code to Verilog"
+msgstr ""
+
+#: ../../requirements.rst:184
+msgid "`wishbone-utils <https://github.com/litex-hub/wishbone-utils>`__"
+msgstr ""
+
+#: ../../requirements.rst:184
+msgid "Interact with Fomu over USB"
+msgstr ""
+
+#: ../../requirements.rst:185
+msgid "**serial console**"
+msgstr ""
+
+#: ../../requirements.rst:185
+msgid "Interact with Python over a virtual console"
+msgstr ""
+
+#: ../../requirements.rst:192
+msgid "Required Hardware"
+msgstr ""
+
+#: ../../requirements.rst:194
+msgid "For this workshop, you will need a Fomu board."
+msgstr ""
+
+#: ../../requirements.rst:196
+msgid "Aside from that, you need a computer with a USB port that can run the :ref:`required-software`."
+msgstr ""
+
+#: ../../requirements.rst:199
+msgid "You should not need any special drivers, though on Linux you may need sudo access, or special udev rules to grant permission to use the USB device from a non-privileged account."
+msgstr ""
+
+#: ../../requirements.rst:203
+msgid "This workshop may be competed with any model of Fomu, though there are some parts that require you to identify which model you have. See the :ref:`which-fomu` section."
+msgstr ""
+
+#: ../../requirements.rst:210
+msgid "Which Fomu do I have?"
+msgstr ""
+
+#: ../../requirements.rst:213
+msgid "Hacker"
+msgstr ""
+
+#: ../../requirements.rst:213
+msgid "Production"
+msgstr ""
+
+#: ../../requirements.rst:215
+msgid "**String**"
+msgstr ""
+
+#: ../../requirements.rst:215
+msgid "hacker"
+msgstr ""
+
+#: ../../requirements.rst:215
+msgid "pvt"
+msgstr ""
+
+#: ../../requirements.rst:217
+msgid "**Bash Command**"
+msgstr ""
+
+#: ../../requirements.rst:217
+msgid "``export FOMU_REV=hacker``"
+msgstr ""
+
+#: ../../requirements.rst:217
+msgid "``export FOMU_REV=pvt``"
+msgstr ""
+
+#: ../../requirements.rst:219
+msgid "**Front**"
+msgstr ""
+
+#: ../../requirements.rst:219
+msgid "|Hacker Hardware Front without case|"
+msgstr ""
+
+#: ../../requirements.rst:219
+msgid "|Production Hardware Front without case|"
+msgstr ""
+
+#: ../../requirements.rst:221
+msgid "**Back**"
+msgstr ""
+
+#: ../../requirements.rst:221
+msgid "|Hacker Hardware Back without case|"
+msgstr ""
+
+#: ../../requirements.rst:221
+msgid "|Production Hardware Back without case|"
+msgstr ""
+
+#: ../../requirements.rst:223
+msgid "**In Case**"
+msgstr ""
+
+#: ../../requirements.rst:223
+msgid "|Hacker Hardware Back with case|"
+msgstr ""
+
+#: ../../requirements.rst:223
+msgid "|Production Hardware Back with case|"
+msgstr ""
+
+#: ../../requirements.rst:225
+msgid "**Parts**"
+msgstr ""
+
+#: ../../requirements.rst:225
+msgid "|Hacker Hardware Annotated Diagram|"
+msgstr ""
+
+#: ../../requirements.rst:225
+msgid "|Production Hardware Annotated Diagram|"
+msgstr ""
+
+#: ../../requirements.rst:227
+msgid "**Color**"
+msgstr ""
+
+#: ../../requirements.rst:227
+msgid "|Dark Blue|"
+msgstr ""
+
+#: ../../requirements.rst:227
+msgid "|Cyan Light Blue|"
+msgstr ""
+
+#: ../../requirements.rst:229
+msgid "**Bootloader**"
+msgstr ""
+
+#: ../../requirements.rst:229
+msgid "Fomu **Hacker** running DFU Bootloader vX.X.X"
+msgstr ""
+
+#: ../../requirements.rst:229
+msgid "Fomu **PVT** running DFU Bootloader vX.X.X"
+msgstr ""
+
+#: ../../requirements.rst:231
+msgid "**Description**"
+msgstr ""
+
+#: ../../requirements.rst:231
+msgid "These are the original design and cut corners to make it easier to manufacture. If you received one directly from Tim before 36C3, you probably have one of these. Hacker boards have white silkscreen on the back."
+msgstr ""
+
+#: ../../requirements.rst:231
+msgid "If you ordered a Fomu from Crowd Supply, this is the model you'll receive. It is small, and fits in a USB port. There is no silkscreen on it. This model of Fomu has a large silver crystal oscillator that is the tallest component on the board."
+msgstr ""
+
+#: ../../requirements.rst:236
+msgid "**Schematic**"
+msgstr ""
+
+#: ../../requirements.rst:236
+msgid "`schematic-hacker.pdf <_static/reference/schematic-hacker.pdf>`__"
+msgstr ""
+
+#: ../../requirements.rst:236
+msgid "`schematic-pvt.pdf <_static/reference/schematic-pvt.pdf>`__"
+msgstr ""
+
+#: ../../requirements.rst:238
+msgid "**Received at**"
+msgstr ""
+
+#: ../../requirements.rst:238
+msgid "From Tim at 35C3, CCCamp19, HackADay Supercon 2019"
+msgstr ""
+
+#: ../../requirements.rst:238
+msgid "At RISC-V Summit 2019, 36C3, Crowdsupply, Mouser"
+msgstr ""
+
+#: ../../requirements.rst:240
+msgid "**Buy more**"
+msgstr ""
+
+#: ../../requirements.rst:240
+msgid "End of Life"
+msgstr ""
+
+#: ../../requirements.rst:240
+msgid "`CrowdSupply <https://j.mp/fomu-cs>`__,"
+msgstr ""
+
+#: ../../requirements.rst:263
+msgid "There are also Fomu EVT boards which were shipped to early backers of the Fomu crowd funding campaign. This model of Fomu is about the size of a credit card. It should have the text “Fomu EVT3” written across it in white silkscreen. If you have a different EVT board such as EVT2 or EVT1, they should work also."
+msgstr ""
+
+#: ../../requirements.rst:273
+msgid "Required Drivers"
+msgstr ""
+
+#: ../../requirements.rst:275
+msgid "On most systems the Fomu board does **not** need any special drivers."
+msgstr ""
+
+#: ../../requirements.rst:277
+msgid "On Windows 10 or newer you do not need to install anything."
+msgstr ""
+
+#: ../../requirements.rst:278
+msgid "On Windows systems **earlier** than Windows 10 you will need to :ref:`windows-zadig`."
+msgstr ""
+
+#: ../../requirements.rst:280
+msgid "On MacOS X you do not need to install any drivers."
+msgstr ""
+
+#: ../../requirements.rst:281
+msgid "On Linux you do not need to install any drivers, **however** you may need ``sudo`` access unless you :ref:`linux-udev` to grant permission to use the USB device from a non-privileged account."
+msgstr ""
+
+#: ../../requirements.rst:289
+msgid "Setup udev rules"
+msgstr ""
+
+#: ../../requirements.rst:293
+msgid "This set up is for Linux **only**."
+msgstr ""
+
+#: ../../requirements.rst:295
+msgid "Setting up these udev rules grant permissions to use the USB device from a non-privileged account."
+msgstr ""
+
+#: ../../requirements.rst:298
+msgid "In Linux, try running ``dfu-util -l``, and if you get an error message like the following you should add a ``udev`` rule as to give your user permission to the usb device."
+msgstr ""
+
+#: ../../requirements.rst:317
+msgid "Steps to set up udev rule"
+msgstr ""
+
+#: ../../requirements.rst:319
+msgid "Add your user to the plugdev group"
+msgstr ""
+
+#: ../../requirements.rst:326
+msgid "Check you are in the ``plugdev`` group with ``id $USER``"
+msgstr ""
+
+#: ../../requirements.rst:334
+msgid "You **will** need to log out and log in again in order to be a member of the ``plugdev`` group."
+msgstr ""
+
+#: ../../requirements.rst:338
+msgid "You **must** log out and then log in again for the group addition to take affect."
+msgstr ""
+
+#: ../../requirements.rst:340
+msgid "Check you are in the ``plugdev`` group with ``groups``"
+msgstr ""
+
+#: ../../requirements.rst:348
+msgid "Create a file named ``/etc/udev/rules.d/99-fomu.rules`` and add the following:"
+msgstr ""
+
+#: ../../requirements.rst:354
+msgid "Reload the udev-rules using the following:"
+msgstr ""
+
+#: ../../requirements.rst:365
+msgid "Installing Zadig Drivers"
+msgstr ""
+
+#: ../../requirements.rst:369
+msgid "This set up is only needed for Windows system **earlier** than Windows 10."
+msgstr ""
+
+#: ../../requirements.rst:371
+msgid "Download `Zadig <https://zadig.akeo.ie/>`__."
+msgstr ""
+
+#: ../../requirements.rst:372
+msgid "Open Zadig."
+msgstr ""
+
+#: ../../requirements.rst:373
+msgid "Under Options, select \"List All Devices\"."
+msgstr ""
+
+#: ../../requirements.rst:374
+msgid "In the dropdown, select your Fomu and in the field right of the green arrow choose the `WinUSB` driver and hit Upgrade Driver."
+msgstr ""

--- a/docs/translations/pot/riscv.pot
+++ b/docs/translations/pot/riscv.pot
@@ -1,0 +1,189 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../riscv.rst:2
+msgid "Fomu as a CPU"
+msgstr ""
+
+#: ../../riscv.rst:4
+msgid "The MicroPython interface is simply a RISC-V program. It interacts with the RISC-V softcore inside Fomu by reading and writing memory directly."
+msgstr ""
+
+#: ../../riscv.rst:7
+msgid "The CPU in Fomu is built on LiteX, which places every device on a Wishbone bus. This is a 32-bit internal bus that maps peripherals into memory."
+msgstr ""
+
+#: ../../riscv.rst:15
+msgid "If you look at the diagram above, you can see that everything in the system is on the Wishbone bus. The CPU is a bus master, and can initiate reads and writes. The system’s RAM is on the wishbone bus, and is currently located at address ``0x10000000``. The boot ROM is also on the bus, and is located at ``0x00000000``. There is also SPI flash which is memory-mapped, so when you load your program onto the SPI flash it shows up on the Wishbone bus at offset ``0x20040000``."
+msgstr ""
+
+#: ../../riscv.rst:23
+msgid "The Configuration and Status Registers (CSRs) all show up at offset ``0xe0000000``. These are the registers we were accessing from Python. Just like before, these special memory addresses correspond to control values."
+msgstr ""
+
+#: ../../riscv.rst:28
+msgid "You’ll notice a “Bridge” in the diagram above. This is an optional feature that we ship by default on Fomu. It bridges the Wishbone bus to another device. In our case, it makes Wishbone available over USB."
+msgstr ""
+
+#: ../../riscv.rst:36
+msgid "The above image shows the structure of a special USB packet we can generate to access the Wishbone bus from a host PC. It lets us do two things: Read a 32-bit value from Wishbone, or write a 32-bit value to Wishbone. These two primitives give us complete control over Fomu."
+msgstr ""
+
+#: ../../riscv.rst:41
+msgid "Recall these definitions from earlier:"
+msgstr ""
+
+#: ../../riscv.rst:47
+msgid "We can use the ``wishbone-tool`` program to read these values directly out of Fomu:"
+msgstr ""
+
+#: ../../riscv.rst:60
+msgid "The three values correspond to the version number of the board at time of writing: v2.0.3."
+msgstr ""
+
+#: ../../riscv.rst:63
+msgid "We can also read and write directly to memory. Recall that memory is mapped to address ``0x10000000``. Let’s write a test value there and try to read it back."
+msgstr ""
+
+#: ../../riscv.rst:75
+msgid "We can see that the value got stored in memory, just like we thought it would. The bridge is working, and we have access to Fomu over USB."
+msgstr ""
+
+#: ../../riscv.rst:79
+msgid "Interacting with the LED Directly"
+msgstr ""
+
+#: ../../riscv.rst:81
+msgid "Recall the LED block from Python. We used ``rgb.write_raw()`` to write values to the LED block. Because of how the LED block is implemented, we need to actually make two writes to the Wishbone bus in order to write one value to the LED block. The first write sets the address, and the second write sends the actual data."
+msgstr ""
+
+#: ../../riscv.rst:87
+msgid "The registers for the LED block are defined as:"
+msgstr ""
+
+#: ../../riscv.rst:94
+msgid "Let’s change the red color to the maximum value. To do that, we’ll write a ``1`` to the address register, and ``0xff`` to the data register:"
+msgstr ""
+
+#: ../../riscv.rst:103
+msgid "We can see that the LED immediately changed its behavior. Try playing around with various values to see what combinations you can come up with!"
+msgstr ""
+
+#: ../../riscv.rst:107
+msgid "You can reset Fomu by writing a special value to the ``CSR_REBOOT_CTRL`` register at ``0xe0006000L``. All writes to this register must start with ``0xac``, to ensure random values aren’t written. We can reboot Fomu by simply writing this value:"
+msgstr ""
+
+#: ../../riscv.rst:120
+msgid "We can see that ``wishbone-tool`` has crashed with an error of ``USBError(Pipe)``, because the USB device went away as we were talking to it. This is expected behavior. Fomu should be back to its normal color and blink rate now."
+msgstr ""
+
+#: ../../riscv.rst:126
+msgid "Compiling RISC-V Code"
+msgstr ""
+
+#: ../../riscv.rst:128
+msgid "Of course, Fomu’s softcore is a full CPU, so we can write C code for it. Go to the ``riscv-blink/`` directory and run ``make``. This will generate ``riscv-blink.dfu``, which we can load onto Fomu."
+msgstr ""
+
+#: ../../riscv.rst:164
+msgid "This will load the binary onto Fomu and start it immediately. The LED should be blinking quickly in a rainbow pattern. Congratulations! You’ve compiled and loaded a RISC-V program onto a softcore."
+msgstr ""
+
+#: ../../riscv.rst:168
+msgid "Let’s modify the program by increasing the fade rate so much that it appears solid. First, reboot Fomu by running ``wishbone-tool 0xe0006000 0xac``. Next, apply the following patch to ``src/main.c``:"
+msgstr ""
+
+#: ../../riscv.rst:186
+msgid "What this does is increase the LED blink rate from 250 Hz to a much higher value. Compile this and load it again with ``dfu-util -D riscv-blink.bin``. The blink rate should appear solid, because it’s blinking too quickly to see."
+msgstr ""
+
+#: ../../riscv.rst:192
+msgid "Debugging RISC-V Code"
+msgstr ""
+
+#: ../../riscv.rst:194
+msgid "Because we have ``peek`` and ``poke``, and because the USB bridge is a bus master, we can actually halt (and reset!) the CPU over the USB bridge. We can go even further and attach a full debugger to it!"
+msgstr ""
+
+#: ../../riscv.rst:198
+msgid "To start with, run ``wishbone-tool -s gdb``:"
+msgstr ""
+
+#: ../../riscv.rst:207
+msgid "In a second window, run gdb on ``riscv-blink.elf``:"
+msgstr ""
+
+#: ../../riscv.rst:233
+msgid "If we run ``bt`` we can get a backtrace, and chances are that we landed in an ``msleep`` function:"
+msgstr ""
+
+#: ../../riscv.rst:245
+msgid "We can insert breakpoints, step, continue execution, and generally debug the entire system. We can even reset the program by running ``mon reset``."
+msgstr ""
+
+#: ../../riscv.rst:251
+msgid "Using Rust"
+msgstr ""
+
+#: ../../riscv.rst:253
+msgid "As an alternative to C, the `Rust Language <https://www.rust-lang.org/>`_ can be used to write software for the Fomu softcore. To install Rust, follow the instructions on https://rustup.rs/. After installing Rust, we can install support for RISCV targets using ``rustup``:"
+msgstr ""
+
+#: ../../riscv.rst:264
+msgid "A Rust version of the C program used above is located in the ``riscv-rust-blink`` directory. Change into that directory, and build it using ``cargo``, the Rust package manager:"
+msgstr ""
+
+#: ../../riscv.rst:292
+msgid "The resulting binary is located in the target subfolder: ``target/riscv32i-unknown-none-elf/release/riscv-rust-blink``. It can be flashed using the ``flash.sh`` script, also located in the ``riscv-rust-blink`` folder:"
+msgstr ""
+
+#: ../../riscv.rst:331
+msgid "Now the Fomu should blink in the same rainbow pattern as before."
+msgstr ""
+
+#: ../../riscv.rst:336
+msgid "The Rust example currently does not support the USB functionality. After programming the example, we will not be able to acces the Fomu over USB anymore. To enable USB again, we have to reset the Fomu by removing it from the USB port and plugging it in again."
+msgstr ""
+
+#: ../../riscv.rst:342
+msgid "Further RISC-V experiments"
+msgstr ""
+
+#: ../../riscv.rst:344
+msgid "The `TinyUSB <https://github.com/hathach/tinyusb>`__ USB stack supports Fomu. To get started with it, you might compile the mass storage example it provides. To do so, follow these steps:"
+msgstr ""
+
+#: ../../riscv.rst:346
+msgid "Clone the TinyUSB git repository: ``git clone https://github.com/hathach/tinyusb`` (you don't need to initialize the subrepositories)"
+msgstr ""
+
+#: ../../riscv.rst:347
+msgid "Change to ``tinyusb/examples/device/cdc_msc``"
+msgstr ""
+
+#: ../../riscv.rst:348
+msgid "Compile: ``make BOARD=fomu CROSS_COMPILE=riscv64-unknown-elf-``"
+msgstr ""
+
+#: ../../riscv.rst:349
+msgid "Load it onto the Fomu:  ``dfu-util -D _build/build-fomu/fomu-firmware.bin``"
+msgstr ""
+
+#: ../../riscv.rst:351
+msgid "Fomu should now appear as a USB storage device containing a README."
+msgstr ""

--- a/docs/translations/pot/verilog.pot
+++ b/docs/translations/pot/verilog.pot
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2019, Tomu Project Authors
+# This file is distributed under the same license as the FPGA Tomu (Fomu) Workshop package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FPGA Tomu (Fomu) Workshop 0.1-196-g5985d6b\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-18 04:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../verilog.rst:2
+msgid "Verilog on Fomu"
+msgstr ""
+
+#: ../../verilog.rst:5
+msgid "“Hello world!” - Blink a LED"
+msgstr ""
+
+#: ../../verilog.rst:7
+msgid "The canonical “Hello, world!” of hardware is to blink a LED. The directory ``verilog/blink-expanded`` contains a Verilog example of a blink project. This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern. It also exposes some of the signals on the touchpads, making it possible to probe them with an oscilloscope."
+msgstr ""
+
+#: ../../verilog.rst:13
+msgid "Enter the ``verilog/blink-expanded`` directory and build the demo by using ``make``:"
+msgstr ""
+
+#: ../../verilog.rst:15
+msgid "**Make sure you set the ``FOMU_REV`` value to match your hardware! See the Required Hardware section.**"
+msgstr ""
+
+#: ../../verilog.rst:62
+msgid "You can then load ``blink.dfu`` onto Fomu by using the same ``dfu-util -D`` command we’ve been using so far. You should see a blinking pattern of varying color on your Fomu, indicating your bitstream was successfully loaded."
+msgstr ""
+
+#: ../../verilog.rst:66
+msgid "When writing HDL, a tool called ``yosys`` is used to convert the human readable verilog into a netlist representation, this is called synthesis. Once we have the netlist representation a tool called ``nextpnr`` performs an operation called “place and route” which makes it something that will actually run on the FPGA. This is all done for you using the ``Makefile`` in the ``verilog/blink`` directory."
+msgstr ""
+
+#: ../../verilog.rst:74
+msgid "A big feature of ``nextpnr`` over its predecessor, is the fact that it is timing-driven. This means that a design will be generated with a given clock domain guaranteed to perform fast enough."
+msgstr ""
+
+#: ../../verilog.rst:78
+msgid "When the ``make`` command runs ``nextpnr-ice40`` you will see something similar included in the output:"
+msgstr ""
+
+#: ../../verilog.rst:85
+msgid "This output example shows that we could run ``clk`` at up to 73.26 MHz and it would still be stable, even though we only requested 12.00 MHz. Note that there is some variation between designs depending on how the placer and router decided to lay things out, so your exact frequency numbers might be different."
+msgstr ""
+
+#: ../../verilog.rst:92
+msgid "Reading Input"
+msgstr ""
+
+#: ../../verilog.rst:94
+msgid "There is another small example in ``verilog/blink-expanded`` which shows how to read out some given pins. Build and flash it like described above and see if you can enable the blue and red LED by shorting pins 1+2 or 3+4 on your Fomu (the pins are the exposed contacts sticking out of the USB port)."
+msgstr ""


### PR DESCRIPTION
This PR adds initial support for internationalisation of `fomu-workshop` website content, we however need to make decision about how we are going to structure it to move forward...

There is no support in for internationalisation URIs in Sphinx by default, so I suppose there is some other, to me hidden logic behind the URIs having `en` when [looking at the deployed version](https://workshop.fomu.im/en/latest/).

What is the deployment logic? Where is the site hosted? Wouldn't it be wise to move to GitHub Pages and GitHub Actions for CI/CD pipeline? We could then deploy each language version into a sub-directory (cs, en, de,...) and have a landing page at web-root...

We can also import these Gettext `pot` files into something like [Weblate](https://weblate.org/en/features/), @nijel offers free tier for libre projects like this one and it would make translation of the content a lot easier for less geeky contributors :-)

I believe that could be integrated into CI/CD pipeline also... 