### PR TITLE
Fix references to "verilog/blink" vs "verilog/blink-expanded".

### DIFF
--- a/docs/translations/pot/verilog.pot
+++ b/docs/translations/pot/verilog.pot
@@ -25,11 +25,11 @@ msgid "“Hello world!” - Blink a LED"
 msgstr ""
 
 #: ../../verilog.rst:7
-msgid "The canonical “Hello, world!” of hardware is to blink a LED. The directory ``verilog/blink-expanded`` contains a Verilog example of a blink project. This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern. It also exposes some of the signals on the touchpads, making it possible to probe them with an oscilloscope."
+msgid "The canonical “Hello, world!” of hardware is to blink a LED. The directory ``verilog/blink`` contains a Verilog example of a blink project. This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern. It also exposes some of the signals on the touchpads, making it possible to probe them with an oscilloscope."
 msgstr ""
 
 #: ../../verilog.rst:13
-msgid "Enter the ``verilog/blink-expanded`` directory and build the demo by using ``make``:"
+msgid "Enter the ``verilog/blink`` directory and build the demo by using ``make``:"
 msgstr ""
 
 #: ../../verilog.rst:15

--- a/docs/verilog.rst
+++ b/docs/verilog.rst
@@ -5,12 +5,12 @@ Verilog on Fomu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The canonical “Hello, world!” of hardware is to blink a LED. The
-directory ``verilog/blink-expanded`` contains a Verilog example of a blink
+directory ``verilog/blink`` contains a Verilog example of a blink
 project. This takes the 48 MHz clock and divides it down by a large
 number so you get an on/off pattern. It also exposes some of the signals
 on the touchpads, making it possible to probe them with an oscilloscope.
 
-Enter the ``verilog/blink-expanded`` directory and build the demo by using ``make``:
+Enter the ``verilog/blink`` directory and build the demo by using ``make``:
 
 **Make sure you set the ``FOMU_REV`` value to match your hardware! See
 the Required Hardware section.**


### PR DESCRIPTION
"blink" cycles through 8 colors.  "blink-expanded" responds to inputs.

DO I NEED TO MAKE PARALLEL CHANGES IN translations/pot/verilog.pot?
Is one generated from the other?
Update: I did make the analogous changes in verilog.pot.

Signed-off-by: Tim Callahan <tcal@google.com>