### PR TITLE
sphinxcontrib-verilog-diagrams was renamed to sphinxcontrib-hdl-diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to properly highlight the example sessions and to allow copying only the
 session lines.
 
 Other sphinx extensions which are used include;
- - [`sphinxcontrib-verilog-diagrams`](http://sphinxcontrib-verilog-diagrams.rtfd.io/)
+ - [`sphinxcontrib-hdl-diagrams`](http://sphinxcontrib-hdl-diagrams.rtfd.io/)
    to generate nice diagrams from Verilog examples.
 
  - [`sphinx-wavedrom`](https://github.com/bavovanachte/sphinx-wavedrom) to

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.githubpages',
     'symbolator_sphinx',
-    'sphinxcontrib_verilog_diagrams',
+    'sphinxcontrib_hdl_diagrams',
     'sphinx_tabs.tabs',
     'sphinxcontrib_session',
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,4 +26,4 @@ sphinxcontrib-wavedrom
 symbolator
 
 # Verilog diagrams using Yosys + netlistsvg
-git+https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams.git#egg=sphinxcontrib-verilog-diagrams
+git+https://github.com/SymbiFlow/sphinxcontrib-hdl-diagrams.git#egg=sphinxcontrib-hdl-diagrams


### PR DESCRIPTION
It seems that the package was renamed, but this repo was not updated accordingly. The repository is correctly forwarded, but `doc/conf.py` fails because `sphinxcontrib_verilog_diagrams` does not exist. It is named `sphinxcontrib_hdl_diagrams` now. This PR fixes the requirements file, the Sphinx config file and the README.

Note that several of dependabot's PRs are failing because of this issue.