### PR TITLE
ci: use GITHUB_ENV instead of add-path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.os == 'ubuntu'
       run: |
         curl -L https://ziglang.org/download/0.6.0/zig-linux-x86_64-0.6.0.tar.xz | tar -xJf -
-        echo "::add-path::$(pwd)/zig-linux-x86_64-0.6.0"
+        echo "$(pwd)/zig-linux-x86_64-0.6.0" >> $GITHUB_PATH
 
     - name: Install (Mac OS)
       if: matrix.os == 'macos'


### PR DESCRIPTION
The usage of `add-path` in the Ubuntu job of the contributed GitHub Actions workflow produces a warning annotation: https://github.com/im-tomu/fomu-workshop/actions/runs/289836222.

That is because GitHub deprecated the feature: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/. Writing to an environment variable is recommended instead: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path.