### PR TITLE
ci: rate limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,5 +47,7 @@ jobs:
         ln -s $(which python) /usr/bin/python3
 
     - run: python ./get-toolchain.py
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - run: ./.github/tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         os: [ ubuntu, windows, macos ]
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
In GitHub Actions a token is available by default (`${{ github.token }}`, see https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context). At the same time, `get-toolchain.py` expects an envvar named `GH_TOKEN`. In this PR, the envvar is set, so that authentication is used. This will hopefully reduce rate limit issues. 