### PR TITLE
ci: update gh-pages from branch 'master' only

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
         path: docs/_build/html
 
     - name: Publish site to gh-pages
-      if: github.event_name != 'pull_request'
+      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
       run: |
         cd docs/_build/html
         touch .nojekyll


### PR DESCRIPTION
As discussed in https://github.com/im-tomu/fomu-workshop/pull/317#issuecomment-704425058, this PR ensures that `gh-pages` will be updated from branch `master` only.

All other branches and/or PR will trigger the CI workflow, the site will be built and it will be available as an artifact (zipfile). However, `gh-pages` and [im-tomu.github.io/fomu-workshop](https://im-tomu.github.io/fomu-workshop/) will only be updated once changes are merged into `master`.

/cc @mithro