### PR TITLE
test: preserve TOOLCHAIN_PATH, if set

### DIFF
--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TOOLCHAIN_PATH="$PWD/$(find fomu-toolchain-* -type d -maxdepth 0 2>/dev/null)"
+TOOLCHAIN_PATH="${TOOLCHAIN_PATH:-$PWD/$(find fomu-toolchain-* -type d -maxdepth 0 2>/dev/null)}"
 echo "TOOLCHAIN_PATH: $TOOLCHAIN_PATH"
 
 export PATH=$TOOLCHAIN_PATH/bin:$PATH


### PR DESCRIPTION
This PR allows preserving envvar `TOOLCHAIN_PATH`, in case the user set it to some other value before running the tests.