### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,17 +24,22 @@ __pycache__/
 build/
 test/
 
-# Output from yosys
+# Output from yosys and nextpnr
 abc.history
+*.asc
+*.bit
 
 # Jekyll files
 .bundle
 Gemfile
 Gemfile.lock
-_*
+_*.*
 
 # Fomu Toolchain
 fomu-toolchain*
 
 # Conda Python Environments
 env
+
+# Output from Sphinx
+docs/_build/


### PR DESCRIPTION
The current `_*` entry for ignoring "Jekyll files" does more than that, it ignores any file or directory starting with `_`. However, `docs/_static` is a subdir that we want to have under SCM, because it contains sources for the docs. This PR updates `.gitignore`  so that files starting with `_` are ignored only. BTW, some other items are added.

Apart from that, when building the docs, the following warning is shown:

> requirements.rst:256: WARNING: image file not readable: _static/hw-pvt-back-case-small.jpg

My guess is that whoever that added the images forgot to add that one, and it was not reported by git because of gitignore.