### PR TITLE
ci: add Migen examples to tests.sh

### DIFF
--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -90,3 +90,25 @@ echo '::group::LiteX example for PVT'
 	file build/gateware/top.dfu
 )
 echo '::endgroup::'
+
+echo '::group::Migen Blink example for PVT board'
+(
+
+	set -x
+	cd migen
+	FOMU_REV=pvt ./blink.py
+	file build/top.bin
+	rm -rf build
+)
+echo '::endgroup::'
+
+echo '::group::Migen Blink (expanded) example for PVT board'
+(
+
+	set -x
+	cd migen
+	FOMU_REV=pvt ./blink-expanded.py
+	file build/top.bin
+	rm -rf build
+)
+echo '::endgroup::'


### PR DESCRIPTION
Currently, Migen tests are not executed in CI. This PR adds them to `tests.sh`.