### PR TITLE
board.mk: split PCF from PNRFLAGS

### DIFF
--- a/board.mk
+++ b/board.mk
@@ -1,26 +1,29 @@
 # Different Fomu hardware revisions are wired differently and thus
 # require different configurations for yosys and nextpnr.
 # Configuration is performed by setting the environment variable FOMU_REV accordingly.
+
+PCF_PATH   ?= ../../pcf
+
 ifeq ($(FOMU_REV),evt1)
-YOSYSFLAGS ?= -D EVT=1
+YOSYSFLAGS ?= -D EVT=1 -D EVT1=1 -D HAVE_PMOD=1
 PNRFLAGS   ?= --up5k --package sg48
-PCF        ?= ../../pcf/fomu-evt2.pcf
+PCF        ?= $(PCF_PATH)/fomu-evt2.pcf
 else ifeq ($(FOMU_REV),evt2)
-YOSYSFLAGS ?= -D EVT=1
+YOSYSFLAGS ?= -D EVT=1 -D EVT2=1 -D HAVE_PMOD=1
 PNRFLAGS   ?= --up5k --package sg48
-PCF        ?= ../../pcf/fomu-evt2.pcf
+PCF        ?= $(PCF_PATH)/fomu-evt2.pcf
 else ifeq ($(FOMU_REV),evt3)
-YOSYSFLAGS ?= -D EVT=1
+YOSYSFLAGS ?= -D EVT=1 -D EVT3=1 -D HAVE_PMOD=1
 PNRFLAGS   ?= --up5k --package sg48
-PCF        ?= ../../pcf/fomu-evt3.pcf
+PCF        ?= $(PCF_PATH)/fomu-evt3.pcf
 else ifeq ($(FOMU_REV),hacker)
 YOSYSFLAGS ?= -D HACKER=1
 PNRFLAGS   ?= --up5k --package uwg30
-PCF        ?= ../../pcf/fomu-hacker.pcf
+PCF        ?= $(PCF_PATH)/fomu-hacker.pcf
 else ifeq ($(FOMU_REV),pvt)
 YOSYSFLAGS ?= -D PVT=1
 PNRFLAGS   ?= --up5k --package uwg30
-PCF        ?= ../../pcf/fomu-pvt.pcf
+PCF        ?= $(PCF_PATH)/fomu-pvt.pcf
 else
 $(error Unrecognized FOMU_REV value. must be "evt1", "evt2", "evt3", "pvt", or "hacker")
 endif

--- a/board.mk
+++ b/board.mk
@@ -2,20 +2,25 @@
 # require different configurations for yosys and nextpnr.
 # Configuration is performed by setting the environment variable FOMU_REV accordingly.
 ifeq ($(FOMU_REV),evt1)
-YOSYSFLAGS?= -D EVT=1
-PNRFLAGS  ?= --up5k --package sg48 --pcf ../../pcf/fomu-evt2.pcf
+YOSYSFLAGS ?= -D EVT=1
+PNRFLAGS   ?= --up5k --package sg48
+PCF        ?= ../../pcf/fomu-evt2.pcf
 else ifeq ($(FOMU_REV),evt2)
-YOSYSFLAGS?= -D EVT=1
-PNRFLAGS  ?= --up5k --package sg48 --pcf ../../pcf/fomu-evt2.pcf
+YOSYSFLAGS ?= -D EVT=1
+PNRFLAGS   ?= --up5k --package sg48
+PCF        ?= ../../pcf/fomu-evt2.pcf
 else ifeq ($(FOMU_REV),evt3)
-YOSYSFLAGS?= -D EVT=1
-PNRFLAGS  ?= --up5k --package sg48 --pcf ../../pcf/fomu-evt3.pcf
+YOSYSFLAGS ?= -D EVT=1
+PNRFLAGS   ?= --up5k --package sg48
+PCF        ?= ../../pcf/fomu-evt3.pcf
 else ifeq ($(FOMU_REV),hacker)
-YOSYSFLAGS?= -D HACKER=1
-PNRFLAGS  ?= --up5k --package uwg30 --pcf ../../pcf/fomu-hacker.pcf
+YOSYSFLAGS ?= -D HACKER=1
+PNRFLAGS   ?= --up5k --package uwg30
+PCF        ?= ../../pcf/fomu-hacker.pcf
 else ifeq ($(FOMU_REV),pvt)
-YOSYSFLAGS?= -D PVT=1
-PNRFLAGS  ?= --up5k --package uwg30 --pcf ../../pcf/fomu-pvt.pcf
+YOSYSFLAGS ?= -D PVT=1
+PNRFLAGS   ?= --up5k --package uwg30
+PCF        ?= ../../pcf/fomu-pvt.pcf
 else
 $(error Unrecognized FOMU_REV value. must be "evt1", "evt2", "evt3", "pvt", or "hacker")
 endif

--- a/mixed-hdl/blink/Makefile
+++ b/mixed-hdl/blink/Makefile
@@ -33,9 +33,10 @@ blink.json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json
+blink.asc: blink.json $(PCF)
 	$(NEXTPNR) \
 		$(PNRFLAGS) \
+		--pcf $(PCF) \
 		--json $< \
 		--asc $@
 

--- a/verilog/blink-expanded/Makefile
+++ b/verilog/blink-expanded/Makefile
@@ -9,8 +9,6 @@ NEXTPNR   ?= nextpnr-ice40
 YOSYS     ?= yosys
 ICEPACK   ?= icepack
 
-PCF_PATH ?= ../../pcf
-
 # Add Windows and Unix support
 RM         = rm -rf
 COPY       = cp -a
@@ -29,34 +27,7 @@ RM         = del
 PATH_SEP   = \\
 endif
 
-ifeq ($(FOMU_REV),evt3)
-PCF       ?= $(PCF_PATH)/fomu-evt3.pcf
-PKG       ?= sg48
-YOSYSFLAGS?= -D EVT=1 -D EVT3=1 -D HAVE_PMOD=1
-PNRFLAGS  ?= --up5k --package $(PKG)
-else ifeq ($(FOMU_REV),evt2)
-PCF       ?= $(PCF_PATH)/fomu-evt2.pcf
-PKG       ?= sg48
-YOSYSFLAGS?= -D EVT=1 -D EVT2=1 -D HAVE_PMOD=1
-PNRFLAGS  ?= --up5k --package $(PKG)
-else ifeq ($(FOMU_REV),evt1)
-PCF       ?= $(PCF_PATH)/fomu-evt2.pcf
-PKG       ?= sg48
-YOSYSFLAGS?= -D EVT=1 -D EVT1=1 -D HAVE_PMOD=1
-PNRFLAGS  ?= --up5k --package $(PKG)
-else ifeq ($(FOMU_REV),hacker)
-PCF       ?= $(PCF_PATH)/fomu-hacker.pcf
-PKG       ?= uwg30
-YOSYSFLAGS?= -D HACKER=1
-PNRFLAGS  ?= --up5k --package $(PKG)
-else ifeq ($(FOMU_REV),pvt)
-PCF       ?= $(PCF_PATH)/fomu-pvt.pcf
-PKG       ?= uwg30
-YOSYSFLAGS?= -D PVT=1 -D PVT1=1
-PNRFLAGS  ?= --up5k --package $(PKG)
-else
-$(error Unrecognized FOMU_REV value. must be "evt1", "evt2", "evt3", "pvt", or "hacker")
-endif
+include ../../board.mk
 
 BUILD_DIR  = build
 VSOURCES   = $(wildcard *.v)

--- a/verilog/blink/Makefile
+++ b/verilog/blink/Makefile
@@ -20,9 +20,10 @@ blink.json: blink.v
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json
+blink.asc: blink.json $(PCF)
 	nextpnr-ice40 \
 		$(PNRFLAGS) \
+		--pcf $(PCF) \
 		--json blink.json \
 		--asc blink.asc
 

--- a/vhdl/blink/Makefile
+++ b/vhdl/blink/Makefile
@@ -27,9 +27,10 @@ blink.json: $(VHDL_SYN_FILES)
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json
+blink.asc: blink.json $(PCF)
 	$(NEXTPNR) \
 		$(PNRFLAGS) \
+		--pcf $(PCF) \
 		--json $< \
 		--asc $@
 


### PR DESCRIPTION
As discussed in https://github.com/im-tomu/fomu-workshop/pull/334#discussion_r501902116, this PR restores the dependency of `bling.json` on the PCF file.