### PR TITLE
doc/icestudio: no need to get apio from git anymore

### DIFF
--- a/docs/icestudio.rst
+++ b/docs/icestudio.rst
@@ -3,14 +3,7 @@ Fomu on IceStudio *Nightly*
 
 .. IMPORTANT:: Fomu is currently not supported in the stable releases
   of IceStudio. Development or `nightly <https://github.com/juanmard/icestudio/releases/tag/nightly>`_
-  releases need to be used. Moreover, Apio needs to be updated from
-  the git repository.
-
-  NOTE: on GNU/Linux, first ``source ~/.icestudio/venv/bin/activate``.
-
-  .. code-block:: shell
-
-      pip install -U git+https://github.com/FPGAwars/apio.git@develop#egg=apio
+  releases need to be used.
 
 “Hello world!” - Blink a LED
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
An apio version supporting Fomu was released to PyPI. Therefore, updating it manually from git is not required anymore.