### PR TITLE
gitattributes: add linguist-language attributes for Verilog and VHDL sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,9 @@ Makefile text eol=lf
 *.jpg diff=image
 *.png diff=image
 *.gds diff=gds
+
+# Settings to improve linguist data reporting (used by GitHub)
+*.v                     linguist-language=Verilog
+*.vh                    linguist-language=Verilog
+*.vhd                   linguist-language=VHDL
+*.vhdl                  linguist-language=VHDL


### PR DESCRIPTION
Seen in https://github.com/antonblanchard/microwatt/issues/225