### PR TITLE
doc: temporarily pin sphinx<4.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 docutils
-sphinx>=2.3.1
+sphinx<4.0.0
 sphinx-autobuild
 
 # Better looking Sphinx theme


### PR DESCRIPTION
It seems that sphinx-symbiflow-theme and/or symbolator_sphinx have issues with Sphinx>=4.0.0:

https://github.com/im-tomu/fomu-workshop/runs/2604051307?check_suite_focus=true#step:3:2576
```
Successfully built sphinx-symbiflow-theme sphinxcontrib-session symbolator sphinxcontrib-hdl-diagrams livereload xcffib wavedrom hdlparse nmigen cairocffi
ERROR: sphinx-tabs 3.0.0 has requirement docutils~=0.16.0, but you'll have docutils 0.17.1 which is incompatible.
Installing collected packages: (...)
Running Sphinx v4.0.1
fatal: No names found, cannot describe anything.
loading translations [en]... done

Extension error:
Could not import extension symbolator_sphinx (exception: cannot import name 'ENOENT' from 'sphinx.util.osutil' (/home/runner/work/fomu-workshop/fomu-workshop/docs/env/lib/python3.7/site-packages/sphinx/util/osutil.py))
make: *** [Makefile:46: html] Error 2
```

In this PR, sphinx is pinned to <4.0.0 so that docs can be built while the issue is fixed.

@mithro, were you hit by this issue somewhere else?