### PR TITLE
ci: run hdl tests on all-in-one container

### DIFF
--- a/.github/hdl-tests.sh
+++ b/.github/hdl-tests.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname "$0")/../hdl
+
+echo '::group::Verilog Blink example'
+(
+	set -x
+	cd verilog/blink
+	make FOMU_REV=pvt blink.bit
+	[ -f blink.bit ]
+)
+echo '::endgroup::'
+
+echo '::group::Verilog Blink (expanded) example for Hacker board'
+(
+	set -x
+	cd verilog/blink-expanded
+	make FOMU_REV=hacker blink.bin
+	[ -f blink.bin ]
+)
+echo '::endgroup::'
+
+echo '::group::Verilog Blink (expanded) example for PVT board'
+(
+	set -x
+	cd verilog/blink-expanded
+	make FOMU_REV=pvt blink.bin
+	[ -f blink.bin ]
+)
+echo '::endgroup::'
+
+echo '::group::VHDL Blink example'
+(
+	set -x
+	cd vhdl/blink
+	make FOMU_REV=pvt blink.bit
+	[ -f blink.bit ]
+)
+echo '::endgroup::'
+
+echo '::group::Mixed HDL Blink example'
+(
+	set -x
+	cd mixed/blink
+	make FOMU_REV=pvt blink.bit
+	[ -f blink.bit ]
+)
+echo '::endgroup::'

--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -8,6 +8,8 @@ echo "TOOLCHAIN_PATH: $TOOLCHAIN_PATH"
 export PATH=$TOOLCHAIN_PATH/bin:$PATH
 export GHDL_PREFIX=$TOOLCHAIN_PATH/lib/ghdl
 
+$(dirname "$0")/hdl-tests.sh
+
 echo '::group::RISC-V C Example'
 (
 	set -x
@@ -23,51 +25,6 @@ echo '::group::RISC-V Zig Example'
 	cd riscv-zig-blink
 	zig build
 	file riscv-zig-blink.bin
-)
-echo '::endgroup::'
-
-echo '::group::Verilog Blink example'
-(
-	set -x
-	cd hdl/verilog/blink
-	make FOMU_REV=pvt
-	file blink.dfu
-)
-echo '::endgroup::'
-
-echo '::group::Verilog Blink (expanded) example for Hacker board'
-(
-	set -x
-	cd hdl/verilog/blink-expanded
-	make FOMU_REV=hacker
-	file blink.dfu
-)
-echo '::endgroup::'
-
-echo '::group::Verilog Blink (expanded) example for PVT board'
-(
-	set -x
-	cd hdl/verilog/blink-expanded
-	make FOMU_REV=pvt
-	file blink.dfu
-)
-echo '::endgroup::'
-
-echo '::group::VHDL Blink example'
-(
-	set -x
-	cd hdl/vhdl/blink
-	make FOMU_REV=pvt
-	file blink.dfu
-)
-echo '::endgroup::'
-
-echo '::group::Mixed HDL Blink example'
-(
-	set -x
-	cd hdl/mixed/blink
-	make FOMU_REV=pvt
-	file blink.dfu
 )
 echo '::endgroup::'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,18 @@ on:
 
 jobs:
 
+
   test:
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ ubuntu, windows, macos ]
+        include:
+          - { icon: 🐧, os: ubuntu }
+          - { icon: 🟦, os: windows }
+          - { icon: 🍎, os: macos }
     runs-on: ${{ matrix.os }}-latest
+    name: '${{ matrix.icon}} ${{ matrix.os }}'
     defaults:
       run:
         shell: bash
@@ -59,3 +64,20 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - run: ./.github/tests.sh
+
+
+  all-in-one:
+    name: '🛳️ All-in-one'
+    runs-on: ubuntu-latest
+    env:
+      GHDL_PLUGIN_MODULE: ghdl
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - uses: docker://ghcr.io/hdl/debian-buster/impl
+      with:
+        args: ./.github/hdl-tests.sh

--- a/hdl/mixed/blink/Makefile
+++ b/hdl/mixed/blink/Makefile
@@ -15,6 +15,11 @@ YOSYS     ?= yosys
 NEXTPNR   ?= nextpnr-ice40
 ICEPACK   ?= icepack
 
+# If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
+ifdef GHDL_PLUGIN_MODULE
+YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
+endif
+
 # Default target: run all required targets to build the DFU image.
 all: blink.dfu
 	@true

--- a/hdl/vhdl/blink/Makefile
+++ b/hdl/vhdl/blink/Makefile
@@ -9,6 +9,11 @@ YOSYS     ?= yosys
 NEXTPNR   ?= nextpnr-ice40
 ICEPACK   ?= icepack
 
+# If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
+ifdef GHDL_PLUGIN_MODULE
+YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
+endif
+
 # Default target: run all required targets to build the DFU image.
 all: blink.dfu
 	@true


### PR DESCRIPTION
In this PR, the tests corresponding to the examples in subdir 'hdl' are moved to a separated script (`hdl-tests.sh`). Then, a CI job is added for showcasing how to execute those inside a single container containing all the required tools (GHDL, Yosys, ghdl-yosys-plugin and nextpnr). Other jobs do still execute all the tests, since `hdl-tests.sh` is called from `tests.sh`.
In fomu-toolchain, ghdl-yosys-plugin is statically built into Yosys. However, in containers, it is built as a module. That's why envvar GHDL_PLUGIN_MODULE is added to the vhdl and mixed makefiles.