### PR TITLE
ci: run hdl tests on fine-grained containers 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,25 @@ jobs:
     - uses: docker://ghcr.io/hdl/debian-buster/impl
       with:
         args: ./.github/hdl-tests.sh
+
+
+  fine-grained:
+    name: '🛳️ Fine-grained'
+    runs-on: ubuntu-latest
+    env:
+      GHDL_PLUGIN_MODULE: ghdl
+      CONTAINER_ENGINE: docker
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Pull container images
+      run: |
+        docker pull hdlc/ghdl:yosys
+        docker pull hdlc/nextpnr:ice40
+        docker pull hdlc/icestorm
+
+    - run: ./.github/hdl-tests.sh

--- a/docs/mixed-hdl.rst
+++ b/docs/mixed-hdl.rst
@@ -3,19 +3,18 @@
 Mixed HDL on Fomu
 -----------------
 
-.. HINT:: It is strongly suggested to get familiar with :ref:`HDLs:Verilog` and :ref:`HDLs:VHDL`
-  examples before tinkering with these mixed language use cases.
+.. HINT:: It is strongly suggested to get familiar with :ref:`HDLs:Verilog` and :ref:`HDLs:VHDL` examples before
+  tinkering with these mixed language use cases.
 
 
 “Hello world!” - Blink a LED
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The canonical “Hello, world!” of hardware is to blink a LED. The
-directory ``hdl/mixed/blink`` contains a VHDL + Verilog example of a blink
-project. This takes the 48 MHz clock and divides it down by a large
-number so you get an on/off pattern.
+The canonical “Hello, world!” of hardware is to blink a LED.
+The directory :repo:`hdl/mixed/blink <hdl/mixed/blink>` contains a VHDL + Verilog example of a blink project.
+This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern.
 
-Enter the ``hdl/mixed/blink`` directory and build the demo by using ``make``:
+Enter the :repo:`hdl/mixed/blink <hdl/mixed/blink>` directory and build the demo by using ``make``:
 
 .. session:: shell-session
 
@@ -61,20 +60,21 @@ Enter the ``hdl/mixed/blink`` directory and build the demo by using ``make``:
    Suffix successfully added to file
    $
 
-You can then load ``blink.dfu`` onto Fomu by using ``make load`` or the same
-``dfu-util -D`` command we’ve been using so far. You should see a blinking pattern of
-varying color on your Fomu, indicating your bitstream was successfully loaded.
+You can then load ``blink.dfu`` onto Fomu by using ``make load`` or the same ``dfu-util -D`` command we’ve been using so
+far.
+You should see a blinking pattern of varying color on your Fomu, indicating your bitstream was successfully loaded.
 
-If you take a closer look at the sources in ``hdl/mixed/blink``, you will find that
+If you take a closer look at the sources in :repo:`hdl/mixed/blink <hdl/mixed/blink>`, you will find that
 modules/components ``blink`` and ``clkgen`` are written both in VHDL and Verilog.
-The Makefile uses ``blink.vhd`` and ``clkgen.v`` by default. However, any of the
-following cases produce the same result:
+The :repo:`Makefile <hdl/mixed/blink/Makefile>` uses ``blink.vhd`` and ``clkgen.v`` by default.
+However, any of the following cases produce the same result:
 
 - ``blink.vhd`` + ``clkgen.v``
 - ``blink.v`` + ``clkgen.vhdl``
 - ``blink.vhd`` + ``clkgen.vhdl``
 - ``blink.v`` + ``clkgen.v``
 
-You can modify variables `VHDL_SYN_FILES` and ``VERILOG_SYN_FILES`` in the Makefile
-for trying other combinations. For a better understanding, it is suggested to compare
-these modules with the single file solutions in :ref:`HDLs:Verilog` and :ref:`HDLs:VHDL`.
+You can modify variables `VHDL_SYN_FILES` and ``VERILOG_SYN_FILES`` in the :repo:`Makefile <hdl/mixed/blink/Makefile>`
+for trying other combinations.
+For a better understanding, it is suggested to compare these modules with the single file solutions in
+:ref:`HDLs:Verilog` and :ref:`HDLs:VHDL`.

--- a/docs/requirements/software.rst
+++ b/docs/requirements/software.rst
@@ -3,13 +3,21 @@
 Required Software
 #################
 
+Fomu requires specialized software.
+
 .. NOTE::
    If you’re taking this workshop as a class, the toolchains are provided
    on the USB disk.
 
-Fomu requires specialized software. This software is provided for GNU/Linux, macOS,
-and Windows, via `Fomu Toolchain <https://github.com/im-tomu/fomu-toolchain/releases/latest>`__.
+Static builds of this software are provided for GNU/Linux, macOS, and Windows via
+`Fomu Toolchain <https://github.com/im-tomu/fomu-toolchain/releases/latest>`__.
+
 Debian packages are also `available for Raspberry Pi <https://github.com/im-tomu/fomu-raspbian-packages>`__.
+
+Moreover, some examples can be executed using :ref:`required-software:containers`.
+
+Fomu Toolchain
+--------------
 
 To install the software, extract it somewhere on your computer, then
 open up a terminal window and add that directory to your ``PATH``:
@@ -100,3 +108,39 @@ Type ``exit`` to quit ``yosys``.
 .. NOTE::
    See the README of `Fomu Toolchain <https://github.com/im-tomu/fomu-toolchain/releases/latest>`_
    for a complete list of the tools included in the toolchain.
+
+.. _required-software:containers:
+
+Containers
+----------
+
+There are several projects which provide ready to use container images including open source EDA tools.
+One of those is `hdl/containers <https://hdl.github.io/containers/>`__.
+As explained in `hdl.github.io/containers: Usage <https://hdl.github.io/containers/#_usage>`__, there are two main
+strategies for running EDA tools through containers:
+
+* All-in-one: a single container is used, which includes all the required tools and dependencies.
+  `make` and all the tools are executed inside that single container.
+* Fine-grained: `make` is executed on the host. For each tool/step, an specific container is used.
+
+Both strategies are supported by the examples in subdir :repo:`hdl <hdl>` of this repository.
+Users willing to run those examples with containers need to take care about the following environment variables:
+
+* `GHDL_PLUGIN_MODULE`: while ghdl-yosys-plugin is built into Yosys in the fomu-toolchain, it is provided as a module in
+  most containers.
+  Typically, `GHDL_PLUGIN_MODULE=ghdl` is required.
+  Some specific containers might require `GHDL_PLUGIN_MODULE=path/to/ghdl-plugin-name.so`.
+* `CONTAINER_ENGINE`: in order to enable the fine-grained approach, `CONTAINER_ENGINE` needs to contain the CLI tool
+  name of a container engine, such as `docker` or `podman`.
+  This variable needs to be unset for the all-in-one approach.
+  In that case, the build is agnostic to the fact that everything is being done inside a container.
+
+  .. NOTE::
+    By default, container images defined in :repo:`hdl/container.mk <hdl/container.mk>` are used when
+    `CONTAINER_ENGINE` is set.
+    It's up to the users to customise that file in order to use different container images, or for executing some of the
+    tools locally.
+
+.. TIP::
+  Find both approaches (and environment variables) used in the CI workflow
+  (:repo:`.github/workflows/test.yml <.github/workflows/test.yml>`) of this repository.

--- a/docs/verilog.rst
+++ b/docs/verilog.rst
@@ -6,12 +6,11 @@ Verilog on Fomu
 “Hello world!” - Blink a LED
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The canonical “Hello, world!” of hardware is to blink a LED. The
-directory ``hdl/verilog/blink`` contains a Verilog example of a blink
-project. This takes the 48 MHz clock and divides it down by a large
-number so you get an on/off pattern.
+The canonical “Hello, world!” of hardware is to blink a LED.
+The directory :repo:`hdl/verilog/blink <hdl/verilog/blink>` contains a Verilog example of a blink project.
+This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern.
 
-Enter the ``hdl/verilog/blink`` directory and build the demo by using ``make``:
+Enter the :repo:`hdl/verilog/blink <hdl/verilog/blink>` directory and build the demo by using ``make``:
 
 **Make sure you set the** ``FOMU_REV`` **value to match your hardware!** See :ref:`required-hardware`.
 
@@ -59,15 +58,14 @@ Enter the ``hdl/verilog/blink`` directory and build the demo by using ``make``:
    Suffix successfully added to file
    $
 
-You can then load ``blink.dfu`` onto Fomu by using the same ``dfu-util -D``
-command we’ve been using so far. You should see a blinking pattern of
-varying color on your Fomu, indicating your bitstream was successfully loaded.
+You can then load ``blink.dfu`` onto Fomu by using the same ``dfu-util -D`` command we’ve been using so far.
+You should see a blinking pattern of varying color on your Fomu, indicating your bitstream was successfully loaded.
 
 
 Reading Input
 ^^^^^^^^^^^^^
 
-There is another small example in ``hdl/verilog/blink-expanded`` which shows
-how to read out some given pins. Build and flash it like described above
-and see if you can enable the blue and red LED by shorting pins 1+2 or 3+4
-on your Fomu (the pins are the exposed contacts sticking out of the USB port).
+There is another small example in :repo:`hdl/verilog/blink-expanded <hdl/verilog/blink-expanded>` which shows how to read
+out some given pins.
+Build and flash it like described above and see if you can enable the blue and red LED by shorting pins 1+2 or 3+4 on
+your Fomu (the pins are the exposed contacts sticking out of the USB port).

--- a/docs/vhdl.rst
+++ b/docs/vhdl.rst
@@ -3,20 +3,19 @@
 VHDL on Fomu
 ------------
 
-.. HINT:: Component declarations for instantiating hard cores (such as the
-  ones in ``sb_ice40_components.vhd``) are found in the installation of
+.. HINT:: Component declarations for instantiating hard cores (such as the ones in
+  :repo:`hdl/sb_ice40_components.vhd <hdl/sb_ice40_components.vhd>`) are found in the installation of
   `iCEcube2 <http://www.latticesemi.com/iCEcube2>`_.
 
 
 “Hello world!” - Blink a LED
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The canonical “Hello, world!” of hardware is to blink a LED. The
-directory ``hdl/vhdl/blink`` contains a VHDL example of a blink
-project. This takes the 48 MHz clock and divides it down by a large
-number so you get an on/off pattern.
+The canonical “Hello, world!” of hardware is to blink a LED.
+The directory :repo:`hdl/vhdl/blink <hdl/vhdl/blink>` contains a VHDL example of a blink project.
+This takes the 48 MHz clock and divides it down by a large number so you get an on/off pattern.
 
-Enter the ``hdl/vhdl/blink`` directory and build the demo by using ``make``:
+Enter the :repo:`hdl/vhdl/blink <hdl/vhdl/blink>` directory and build the demo by using ``make``:
 
 **Make sure you set the** ``FOMU_REV`` **value to match your hardware!** See :ref:`required-hardware`.
 
@@ -64,6 +63,6 @@ Enter the ``hdl/vhdl/blink`` directory and build the demo by using ``make``:
    Suffix successfully added to file
    $
 
-You can then load ``blink.dfu`` onto Fomu by using ``make load`` or the same
-``dfu-util -D`` command we’ve been using so far. You should see a blinking pattern of
-varying color on your Fomu, indicating your bitstream was successfully loaded.
+You can then load ``blink.dfu`` onto Fomu by using ``make load`` or the same ``dfu-util -D`` command we’ve been using so
+far.
+You should see a blinking pattern of varying color on your Fomu, indicating your bitstream was successfully loaded.

--- a/hdl/container.mk
+++ b/hdl/container.mk
@@ -1,0 +1,12 @@
+CONTAINER_ENGINE ?= docker
+
+PWD = $(shell pwd)
+CONTAINER_ARGS = run \
+	--rm \
+	-v /$(PWD)/../../..://wrk \
+	-w //wrk/hdl/$(notdir $(shell dirname $(PWD)))/$(notdir $(PWD))
+
+GHDL    = $(CONTAINER_ENGINE) $(CONTAINER_ARGS) hdlc/ghdl:yosys ghdl
+YOSYS   = $(CONTAINER_ENGINE) $(CONTAINER_ARGS) hdlc/ghdl:yosys yosys
+NEXTPNR = $(CONTAINER_ENGINE) $(CONTAINER_ARGS) hdlc/nextpnr:ice40 nextpnr-ice40
+ICEPACK = $(CONTAINER_ENGINE) $(CONTAINER_ARGS) hdlc/icestorm icepack

--- a/hdl/mixed/blink/Makefile
+++ b/hdl/mixed/blink/Makefile
@@ -23,6 +23,11 @@ ifdef GHDL_PLUGIN_MODULE
 YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
 endif
 
+# If a container engine is used, each tool is executed in a separated container
+ifdef CONTAINER_ENGINE
+include ../../container.mk
+endif
+
 # Default target: run all required targets to build the DFU image.
 all: $(DESIGN).dfu
 	@true

--- a/hdl/mixed/blink/Makefile
+++ b/hdl/mixed/blink/Makefile
@@ -1,7 +1,10 @@
 include ../../board.mk
 
+DESIGN = blink
+TOP    = Fomu_Blink
+
 # VHDL top with instantiated Verilog
-VHDL_SYN_FILES = ../../sb_ice40_components.vhd blink.vhd
+VHDL_SYN_FILES    = ../../sb_ice40_components.vhd blink.vhd
 VERILOG_SYN_FILES = clkgen.v
 
 # Verilog top with instantiated VHDL
@@ -9,11 +12,11 @@ VERILOG_SYN_FILES = clkgen.v
 #VERILOG_SYN_FILES = blink.v
 
 GHDL_FLAGS += --std=08
-GHDL      ?= ghdl
-GHDLSYNTH ?= ghdl
-YOSYS     ?= yosys
-NEXTPNR   ?= nextpnr-ice40
-ICEPACK   ?= icepack
+GHDL       ?= ghdl
+GHDLSYNTH  ?= ghdl
+YOSYS      ?= yosys
+NEXTPNR    ?= nextpnr-ice40
+ICEPACK    ?= icepack
 
 # If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
 ifdef GHDL_PLUGIN_MODULE
@@ -21,24 +24,24 @@ YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
 endif
 
 # Default target: run all required targets to build the DFU image.
-all: blink.dfu
+all: $(DESIGN).dfu
 	@true
 
 .DEFAULT: all
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
-blink.json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
+$(DESIGN).json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
 	$(YOSYS) $(YOSYSFLAGS) \
 		-p \
 		"$(GHDLSYNTH) $(GHDL_FLAGS) $(VHDL_SYN_FILES) -e; \
 		synth_ice40 \
-		-top Fomu_Blink \
+		-top $(TOP) \
 		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json $(PCF)
+$(DESIGN).asc: $(DESIGN).json $(PCF)
 	$(NEXTPNR) \
 		$(PNRFLAGS) \
 		--pcf $(PCF) \
@@ -47,16 +50,16 @@ blink.asc: blink.json $(PCF)
 
 # Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
 # This is called the bitstream generation step.
-blink.bit: blink.asc
+$(DESIGN).bit: $(DESIGN).asc
 	$(ICEPACK) $< $@
 
 # Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-blink.dfu: blink.bit
+$(DESIGN).dfu: $(DESIGN).bit
 	cp $< $@
 	dfu-suffix -v 1209 -p 70b1 -a $@
 
 # Use df-util to load the DFU image onto the Fomu.
-load: blink.dfu
+load: $(DESIGN).dfu
 	dfu-util -D $<
 
 .PHONY: load

--- a/hdl/verilog/blink-expanded/Makefile
+++ b/hdl/verilog/blink-expanded/Makefile
@@ -1,5 +1,9 @@
-PACKAGE   ?= blink
-TOP       ?= $(PACKAGE)
+include ../../board.mk
+
+DESIGN = blink
+TOP    = $(DESIGN)
+
+VERILOG_SYN_FILES = blink.v
 
 # Currently GIT_VERSION is unusd and there are no tags, so skip calculating it
 #GIT_VERSION := $(shell git describe --tags)
@@ -27,40 +31,38 @@ RM         = del
 PATH_SEP   = \\
 endif
 
-include ../../board.mk
-
 BUILD_DIR  = build
 VSOURCES   = $(wildcard *.v)
 QUIET      = @
 
 ALL        = all
-TARGET     = $(PACKAGE).bin
+TARGET     = $(DESIGN).bin
 CLEAN      = clean
 
-$(ALL): $(TARGET) $(PACKAGE).dfu
-	$(QUIET) echo "Built '$(PACKAGE)' for Fomu $(FOMU_REV)"
+$(ALL): $(TARGET) $(DESIGN).dfu
+	$(QUIET) echo "Built '$(DESIGN)' for Fomu $(FOMU_REV)"
 
 run: $(TARGET)
 	fomu-flash -f $(TARGET)
 
-run-dfu: $(PACKAGE).dfu
-	dfu-util -D $(PACKAGE).dfu
+run-dfu: $(DESIGN).dfu
+	dfu-util -D $(DESIGN).dfu
 
-$(BUILD_DIR)/$(PACKAGE).json: $(VSOURCES) | $(BUILD_DIR)
+$(BUILD_DIR)/$(DESIGN).json: $(VSOURCES) | $(BUILD_DIR)
 	$(QUIET) echo " SYNTH    $@"
-	$(QUIET) $(YOSYS) $(YOSYSFLAGS) -p 'synth_ice40 -top $(TOP) -json $@' $(PACKAGE).v
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) -p 'synth_ice40 -top $(TOP) -json $@' $(VERILOG_SYN_FILES)
 
-$(BUILD_DIR)/$(PACKAGE).asc: $(BUILD_DIR)/$(PACKAGE).json $(PCF)
+$(BUILD_DIR)/$(DESIGN).asc: $(BUILD_DIR)/$(DESIGN).json $(PCF)
 	$(QUIET) echo " PNR      $@"
-	$(QUIET) $(NEXTPNR) $(PNRFLAGS) --json $(BUILD_DIR)/$(PACKAGE).json --pcf $(PCF) --asc $@
+	$(QUIET) $(NEXTPNR) $(PNRFLAGS) --json $(BUILD_DIR)/$(DESIGN).json --pcf $(PCF) --asc $@
 
-$(TARGET): $(BUILD_DIR)/$(PACKAGE).asc
+$(TARGET): $(BUILD_DIR)/$(DESIGN).asc
 	$(QUIET) echo " PACK     $@"
-	$(QUIET) $(ICEPACK) $(BUILD_DIR)/$(PACKAGE).asc $@
+	$(QUIET) $(ICEPACK) $(BUILD_DIR)/$(DESIGN).asc $@
 
-$(PACKAGE).dfu: $(TARGET)
+$(DESIGN).dfu: $(TARGET)
 	$(QUIET) echo "  DFU      $@"
-	$(QUIET) $(COPY) $(PACKAGE).bin $@
+	$(QUIET) $(COPY) $(DESIGN).bin $@
 	$(QUIET) dfu-suffix -v 1209 -p 70b1 -a $@
 
 $(BUILD_DIR):
@@ -73,7 +75,7 @@ clean:
 	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.json))
 	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.asc))"
 	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.asc))
-	$(QUIET) echo "  RM      $(TARGET) $(PACKAGE).bin $(PACKAGE).dfu"
+	$(QUIET) echo "  RM      $(TARGET) $(DESIGN).bin $(DESIGN).dfu"
 	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),abc.history)
 	$(QUIET) echo "  RM      $(TARGET) abc.history"
-	-$(QUIET) $(RM) $(TARGET) $(PACKAGE).bin $(PACKAGE).dfu
+	-$(QUIET) $(RM) $(TARGET) $(DESIGN).bin $(DESIGN).dfu

--- a/hdl/verilog/blink-expanded/Makefile
+++ b/hdl/verilog/blink-expanded/Makefile
@@ -13,6 +13,11 @@ NEXTPNR   ?= nextpnr-ice40
 YOSYS     ?= yosys
 ICEPACK   ?= icepack
 
+# If a container engine is used, each tool is executed in a separated container
+ifdef CONTAINER_ENGINE
+include ../../container.mk
+endif
+
 # Add Windows and Unix support
 RM         = rm -rf
 COPY       = cp -a

--- a/hdl/verilog/blink/Makefile
+++ b/hdl/verilog/blink/Makefile
@@ -14,6 +14,11 @@ YOSYS     ?= yosys
 NEXTPNR   ?= nextpnr-ice40
 ICEPACK   ?= icepack
 
+# If a container engine is used, each tool is executed in a separated container
+ifdef CONTAINER_ENGINE
+include ../../container.mk
+endif
+
 # Default target: run all required targets to build the DFU image.
 all: $(DESIGN).dfu
 	@true

--- a/hdl/verilog/blink/Makefile
+++ b/hdl/verilog/blink/Makefile
@@ -5,49 +5,60 @@
 
 include ../../board.mk
 
+DESIGN = blink
+TOP    = top
+
+VERILOG_SYN_FILES = blink.v
+
+YOSYS     ?= yosys
+NEXTPNR   ?= nextpnr-ice40
+ICEPACK   ?= icepack
+
 # Default target: run all required targets to build the DFU image.
-all: blink.dfu
+all: $(DESIGN).dfu
 	@true
 
 .DEFAULT: all
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
-blink.json: blink.v
-	yosys \
-		$(YOSYSFLAGS) \
-		-p 'synth_ice40 -top top -json blink.json' blink.v
+$(DESIGN).json: $(VERILOG_SYN_FILES)
+	$(YOSYS) $(YOSYSFLAGS) \
+		-p  \
+		"synth_ice40 \
+		-top $(TOP) \
+		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json $(PCF)
-	nextpnr-ice40 \
+$(DESIGN).asc: $(DESIGN).json $(PCF)
+	$(NEXTPNR) \
 		$(PNRFLAGS) \
 		--pcf $(PCF) \
-		--json blink.json \
-		--asc blink.asc
+		--json  $< \
+		--asc $@
 
 # Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
 # This is called the bitstream generation step.
-blink.bit: blink.asc
-	icepack blink.asc blink.bit
+$(DESIGN).bit: $(DESIGN).asc
+	$(ICEPACK) $< $@
 
 # Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-blink.dfu: blink.bit
-	cp blink.bit blink.dfu
-	dfu-suffix -v 1209 -p 70b1 -a blink.dfu
+$(DESIGN).dfu: $(DESIGN).bit
+	cp $< $@
+	dfu-suffix -v 1209 -p 70b1 -a $@
 
 # Use df-util to load the DFU image onto the Fomu.
-load: blink.dfu
-	dfu-util -D blink.dfu
+load: $(DESIGN).dfu
+	dfu-util -D  $<
 
 .PHONY: load
 
 # Cleanup the generated files.
 clean:
-	-rm -f blink.json 	# Generate netlist
-	-rm -f blink.asc 	# FPGA configuration
-	-rm -f blink.bit 	# FPGA bitstream
-	-rm -f blink.dfu 	# DFU image loadable onto the Fomu
+	-rm -f $(DESIGN).json 	# Generate netlist
+	-rm -f $(DESIGN).asc 	# FPGA configuration
+	-rm -f $(DESIGN).bit 	# FPGA bitstream
+	-rm -f $(DESIGN).dfu 	# DFU image loadable onto the Fomu
 
 .PHONY: clean

--- a/hdl/vhdl/blink/Makefile
+++ b/hdl/vhdl/blink/Makefile
@@ -1,13 +1,16 @@
 include ../../board.mk
 
+DESIGN = blink
+TOP    = Fomu_Blink
+
 VHDL_SYN_FILES = ../../sb_ice40_components.vhd blink.vhd
 
 GHDL_FLAGS += --std=08
-GHDL      ?= ghdl
-GHDLSYNTH ?= ghdl
-YOSYS     ?= yosys
-NEXTPNR   ?= nextpnr-ice40
-ICEPACK   ?= icepack
+GHDL       ?= ghdl
+GHDLSYNTH  ?= ghdl
+YOSYS      ?= yosys
+NEXTPNR    ?= nextpnr-ice40
+ICEPACK    ?= icepack
 
 # If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
 ifdef GHDL_PLUGIN_MODULE
@@ -22,17 +25,17 @@ all: blink.dfu
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
-blink.json: $(VHDL_SYN_FILES)
+$(DESIGN).json: $(VHDL_SYN_FILES)
 	$(YOSYS) $(YOSYSFLAGS) \
 		-p \
 		"$(GHDLSYNTH) $(GHDL_FLAGS) $^ -e; \
 		synth_ice40 \
-		-top Fomu_Blink \
+		-top $(TOP) \
 		-json $@" 2>&1 | tee yosys-report.txt
 
 # Use **nextpnr** to generate the FPGA configuration.
 # This is called the **place** and **route** step.
-blink.asc: blink.json $(PCF)
+$(DESIGN).asc: $(DESIGN).json $(PCF)
 	$(NEXTPNR) \
 		$(PNRFLAGS) \
 		--pcf $(PCF) \
@@ -41,16 +44,16 @@ blink.asc: blink.json $(PCF)
 
 # Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
 # This is called the bitstream generation step.
-blink.bit: blink.asc
+$(DESIGN).bit: $(DESIGN).asc
 	$(ICEPACK) $< $@
 
 # Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-blink.dfu: blink.bit
+$(DESIGN).dfu: $(DESIGN).bit
 	cp $< $@
 	dfu-suffix -v 1209 -p 70b1 -a $@
 
 # Use df-util to load the DFU image onto the Fomu.
-load: blink.dfu
+load: $(DESIGN).dfu
 	dfu-util -D $<
 
 .PHONY: load

--- a/hdl/vhdl/blink/Makefile
+++ b/hdl/vhdl/blink/Makefile
@@ -17,6 +17,11 @@ ifdef GHDL_PLUGIN_MODULE
 YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
 endif
 
+# If a container engine is used, each tool is executed in a separated container
+ifdef CONTAINER_ENGINE
+include ../../container.mk
+endif
+
 # Default target: run all required targets to build the DFU image.
 all: blink.dfu
 	@true


### PR DESCRIPTION
This is the last in the recent series of PRs. Support for fine-grained usage of containers is added.

- In the existing all-in-one CI job, a single container is used, and make is executed inside.
- In the new fine-grained CI job, make is executed on the host and one container is used for each of the tools.

Replacing "local" tools with containers is done through `container.mk`, allowing users to easily decide which tools to run locally or which specific container images to use.

By the way, variables DESIGN and TOP are used in the Makefiles, for making them more generic.