### PR TITLE
add hdl/PnR_Prog.mk, add MSYS2 CI, update README, test litex/workflow_rgb.py

### DIFF
--- a/.github/hdl-tests.sh
+++ b/.github/hdl-tests.sh
@@ -17,8 +17,8 @@ echo '::group::Verilog Blink (expanded) example for Hacker board'
 (
 	set -x
 	cd verilog/blink-expanded
-	make FOMU_REV=hacker blink.bin
-	[ -f blink.bin ]
+	make FOMU_REV=hacker blink.bit
+	[ -f blink.bit ]
 )
 echo '::endgroup::'
 
@@ -26,8 +26,8 @@ echo '::group::Verilog Blink (expanded) example for PVT board'
 (
 	set -x
 	cd verilog/blink-expanded
-	make FOMU_REV=pvt blink.bin
-	[ -f blink.bin ]
+	make FOMU_REV=pvt blink.bit
+	[ -f blink.bit ]
 )
 echo '::endgroup::'
 

--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -46,6 +46,15 @@ echo '::group::LiteX example for PVT'
 )
 echo '::endgroup::'
 
+echo '::group::LiteX RGB example for PVT'
+(
+	set -x
+	cd litex
+	./workshop_rgb.py --board=pvt
+	file build/gateware/top.dfu
+)
+echo '::endgroup::'
+
 echo '::group::Migen Blink example for PVT board'
 (
 	set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,17 @@ on:
 jobs:
 
 
-  test:
+  fomu-toolchain:
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
         include:
-          - { icon: 🐧, os: ubuntu }
-          - { icon: 🟦, os: windows }
-          - { icon: 🍎, os: macos }
+          - { icon: 🐧, os: Ubuntu }
+          - { icon: 🧊, os: Windows }
+          - { icon: 🍎, os: macOS }
     runs-on: ${{ matrix.os }}-latest
-    name: '${{ matrix.icon}} ${{ matrix.os }}'
+    name: '${{ matrix.icon}} ${{ matrix.os }} | fomu-toolchain'
     defaults:
       run:
         shell: bash
@@ -67,7 +67,7 @@ jobs:
 
 
   all-in-one:
-    name: '🛳️ All-in-one'
+    name: '🛳️ Container | All-in-one'
     runs-on: ubuntu-latest
     env:
       GHDL_PLUGIN_MODULE: ghdl
@@ -84,7 +84,7 @@ jobs:
 
 
   fine-grained:
-    name: '🛳️ Fine-grained'
+    name: '🛳️ Container | Fine-grained'
     runs-on: ubuntu-latest
     env:
       GHDL_PLUGIN_MODULE: ghdl
@@ -101,5 +101,43 @@ jobs:
         docker pull hdlc/ghdl:yosys
         docker pull hdlc/nextpnr:ice40
         docker pull hdlc/icestorm
+
+    - run: ./.github/hdl-tests.sh
+
+
+  msys2:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: [
+          {icon: '🟪', installs: 'MINGW32', arch: i686   },
+          {icon: '🟦', installs: 'MINGW64', arch: x86_64 },
+        ]
+    name: '${{ matrix.icon }} MSYS2 | ${{ matrix.installs }}'
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.installs }}
+        update: true
+        install: >
+          make
+          mingw-w64-${{ matrix.arch }}-icestorm
+          mingw-w64-${{ matrix.arch }}-yosys
+          mingw-w64-${{ matrix.arch }}-nextpnr
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
 
     - run: ./.github/hdl-tests.sh

--- a/README.md
+++ b/README.md
@@ -13,39 +13,42 @@
   -->
 </p>
 
-Hi, I'm Fomu!  [This workshop](https://workshop.fomu.im/) covers the basics of
-Fomu in a top-down approach.  We'll start out by learning **what** Fomu is, **how to
-load software** into Fomu, **how to write software** for Fomu and finally **how to
-write hardware** for Fomu.
+Hi, I'm Fomu!  [This workshop](https://workshop.fomu.im/) covers the basics of Fomu in a top-down approach.
+We'll start out by learning **what** Fomu is, **how to load software** into Fomu, **how to write software** for Fomu and
+finally **how to write hardware** for Fomu.
 
 <p align="center">
   <a title="FPGA Tomu (Fomu) Workshop" href="https://workshop.fomu.im/"><img src="docs/_static/hw-pvt-back-bare-small.jpg"/></a>
   <a title="FPGA Tomu (Fomu) Workshop" href="https://workshop.fomu.im/"><img src="docs/_static/hw-pvt-front-bare-small.jpg"/></a>
 </p>
 
-FPGAs are complex, weird things, so we'll take a gentle approach and start out
-by treating it like a Python interpreter first, and gradually peel away layers
-until we're writing our own hardware registers.  You can take a break at any
-time and explore!  Stop when you feel the concepts are too unfamiliar, or
-plough on and dig deep into the world of hardware.
+FPGAs are complex, weird things, so we'll take a gentle approach and start out by treating it like a Python interpreter
+first, and gradually peel away layers until we're writing our own hardware registers.
+You can take a break at any time and explore!
+Stop when you feel the concepts are too unfamiliar, or plough on and dig deep into the world of hardware.
 
 The contents of this workshop is published at [workshop.fomu.im](https://workshop.fomu.im).
 
 ## Repository Contents
 
 - [docs](./docs) - The actual workshop directions and content.
-- [litex](./litex) - The files required for [the Migen / LiteX section of the
-  workshop](https://workshop.fomu.im/en/latest/migen.html).
-- [reference](./reference) - Extra reference documentation such as schematics
-  and part datasheets.
-- [riscv-blink](./riscv-blink) - The files required for the [Fomu as a RISC-V
-  CPU section of the workshop](https://workshop.fomu.im/en/latest/riscv.html).
-- [verilog](./verilog) - The files required for the [Verilog on Fomu section
-  of the workshop](https://workshop.fomu.im/en/latest/verilog.html).
-- [vhdl](./vhdl) - The files required for the [VHDL on Fomu section
-  of the workshop](https://workshop.fomu.im/en/latest/vhdl.html).
-- [mixed-hdl](./mixed-hdl) - The files required for the [Mixed HDL on Fomu section
-  of the workshop](https://workshop.fomu.im/en/latest/mixedhdl.html).
+- [hdl](./hdl)
+  - [verilog](./hdl/verilog) - The files required for the [Verilog on Fomu](https://workshop.fomu.im/en/latest/verilog.html)
+    section of the workshop.
+  - [vhdl](./hdl/vhdl) - The files required for the [VHDL on Fomu](https://workshop.fomu.im/en/latest/vhdl.html) section
+    of the workshop.
+  - [mixed](./hdl/mixed) - The files required for the [Mixed HDL on Fomu](https://workshop.fomu.im/en/latest/mixedhdl.html)
+    section of the workshop.
+- [icestudio](./icestudio) - The files required for the [Fomu on IceStudio *Nightly*](https://workshop.fomu.im/en/latest/icestudio.html)
+    section of the workshop.
+- [litex](./litex), [migen](./migen) - The files required for the [Migen and LiteX](https://workshop.fomu.im/en/latest/migen.html)
+  section of the workshop.
+- [reference](./reference) - Extra reference documentation such as schematics and part datasheets.
+- riscv
+  - [riscv-blink](./riscv-blink) - The files required for the [Fomu as a CPU](https://workshop.fomu.im/en/latest/riscv.html)
+    section of the workshop.
+  - [riscv-rust-blink](./riscv-rust-blink) - The files required for the [Fomu as a CPU, Using Rust](https://workshop.fomu.im/en/latest/riscv.html#using-rust)
+    section of the workshop.
 
 # Development
 

--- a/hdl/PnR_Prog.mk
+++ b/hdl/PnR_Prog.mk
@@ -1,0 +1,24 @@
+COPY ?= cp -a
+
+# Use **nextpnr** to generate the FPGA configuration.
+# This is called the **place** and **route** step.
+$(DESIGN).asc: $(DESIGN).json $(PCF)
+	$(QUIET) $(NEXTPNR) \
+		$(PNRFLAGS) \
+		--pcf $(PCF) \
+		--json $(DESIGN).json \
+		--asc $@
+
+# Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
+# This is called the bitstream generation step.
+$(DESIGN).bit: $(DESIGN).asc
+	$(QUIET) $(ICEPACK) $< $@
+
+# Use dfu-suffix to generate the DFU image from the FPGA bitstream.
+$(DESIGN).dfu: $(DESIGN).bit
+	$(QUIET) $(COPY) $< $@
+	$(QUIET) dfu-suffix -v 1209 -p 70b1 -a $@
+
+# Use df-util to load the DFU image onto the Fomu.
+load: $(DESIGN).dfu
+	dfu-util -D $<

--- a/hdl/mixed/blink/Makefile
+++ b/hdl/mixed/blink/Makefile
@@ -18,6 +18,8 @@ YOSYS      ?= yosys
 NEXTPNR    ?= nextpnr-ice40
 ICEPACK    ?= icepack
 
+QUIET = @
+
 # If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
 ifdef GHDL_PLUGIN_MODULE
 YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
@@ -30,42 +32,21 @@ endif
 
 # Default target: run all required targets to build the DFU image.
 all: $(DESIGN).dfu
-	@true
+	$(QUIET) echo "Built '$(DESIGN)' for Fomu $(FOMU_REV)"
 
 .DEFAULT: all
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
 $(DESIGN).json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
-	$(YOSYS) $(YOSYSFLAGS) \
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
 		-p \
 		"$(GHDLSYNTH) $(GHDL_FLAGS) $(VHDL_SYN_FILES) -e; \
 		synth_ice40 \
 		-top $(TOP) \
 		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
 
-# Use **nextpnr** to generate the FPGA configuration.
-# This is called the **place** and **route** step.
-$(DESIGN).asc: $(DESIGN).json $(PCF)
-	$(NEXTPNR) \
-		$(PNRFLAGS) \
-		--pcf $(PCF) \
-		--json $< \
-		--asc $@
-
-# Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
-# This is called the bitstream generation step.
-$(DESIGN).bit: $(DESIGN).asc
-	$(ICEPACK) $< $@
-
-# Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-$(DESIGN).dfu: $(DESIGN).bit
-	cp $< $@
-	dfu-suffix -v 1209 -p 70b1 -a $@
-
-# Use df-util to load the DFU image onto the Fomu.
-load: $(DESIGN).dfu
-	dfu-util -D $<
+include ../../PnR_Prog.mk
 
 .PHONY: load
 

--- a/hdl/verilog/blink-expanded/Makefile
+++ b/hdl/verilog/blink-expanded/Makefile
@@ -5,13 +5,11 @@ TOP    = $(DESIGN)
 
 VERILOG_SYN_FILES = blink.v
 
-# Currently GIT_VERSION is unusd and there are no tags, so skip calculating it
-#GIT_VERSION := $(shell git describe --tags)
-
-# Default programs
-NEXTPNR   ?= nextpnr-ice40
 YOSYS     ?= yosys
+NEXTPNR   ?= nextpnr-ice40
 ICEPACK   ?= icepack
+
+QUIET = @
 
 # If a container engine is used, each tool is executed in a separated container
 ifdef CONTAINER_ENGINE
@@ -36,51 +34,26 @@ RM         = del
 PATH_SEP   = \\
 endif
 
-BUILD_DIR  = build
-VSOURCES   = $(wildcard *.v)
-QUIET      = @
-
-ALL        = all
-TARGET     = $(DESIGN).bin
-CLEAN      = clean
-
-$(ALL): $(TARGET) $(DESIGN).dfu
+all: $(DESIGN).dfu
 	$(QUIET) echo "Built '$(DESIGN)' for Fomu $(FOMU_REV)"
 
-run: $(TARGET)
-	fomu-flash -f $(TARGET)
+.DEFAULT: all
 
-run-dfu: $(DESIGN).dfu
-	dfu-util -D $(DESIGN).dfu
+# Use *Yosys* to generate the synthesized netlist.
+# This is called the **synthesis** and **tech mapping** step.
+$(DESIGN).json: $(VERILOG_SYN_FILES)
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
+		-p \
+		"synth_ice40 \
+		-top $(TOP) \
+		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
 
-$(BUILD_DIR)/$(DESIGN).json: $(VSOURCES) | $(BUILD_DIR)
-	$(QUIET) echo " SYNTH    $@"
-	$(QUIET) $(YOSYS) $(YOSYSFLAGS) -p 'synth_ice40 -top $(TOP) -json $@' $(VERILOG_SYN_FILES)
+include ../../PnR_Prog.mk
 
-$(BUILD_DIR)/$(DESIGN).asc: $(BUILD_DIR)/$(DESIGN).json $(PCF)
-	$(QUIET) echo " PNR      $@"
-	$(QUIET) $(NEXTPNR) $(PNRFLAGS) --json $(BUILD_DIR)/$(DESIGN).json --pcf $(PCF) --asc $@
+run: $(DESIGN).bin
+	fomu-flash -f $<
 
-$(TARGET): $(BUILD_DIR)/$(DESIGN).asc
-	$(QUIET) echo " PACK     $@"
-	$(QUIET) $(ICEPACK) $(BUILD_DIR)/$(DESIGN).asc $@
-
-$(DESIGN).dfu: $(TARGET)
-	$(QUIET) echo "  DFU      $@"
-	$(QUIET) $(COPY) $(DESIGN).bin $@
-	$(QUIET) dfu-suffix -v 1209 -p 70b1 -a $@
-
-$(BUILD_DIR):
-	$(QUIET) mkdir $(BUILD_DIR)
-
-.PHONY: clean
+.PHONY: load
 
 clean:
-	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.json))"
-	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.json))
-	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.asc))"
-	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(BUILD_DIR)/*.asc))
-	$(QUIET) echo "  RM      $(TARGET) $(DESIGN).bin $(DESIGN).dfu"
-	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),abc.history)
-	$(QUIET) echo "  RM      $(TARGET) abc.history"
-	-$(QUIET) $(RM) $(TARGET) $(DESIGN).bin $(DESIGN).dfu
+	rm -fr *.json *-report.txt *.asc *.bit *.dfu

--- a/hdl/verilog/blink-expanded/Makefile
+++ b/hdl/verilog/blink-expanded/Makefile
@@ -21,6 +21,7 @@ RM         = rm -rf
 COPY       = cp -a
 PATH_SEP   = /
 ifeq ($(OS),Windows_NT)
+ifndef MSYSTEM
 # When SHELL=sh.exe and this actually exists, make will silently
 # switch to using that instead of cmd.exe.  Unfortunately, there's
 # no way to tell which environment we're running under without either
@@ -32,6 +33,7 @@ SHELL      = cmd.exe
 COPY       = copy
 RM         = del
 PATH_SEP   = \\
+endif
 endif
 
 all: $(DESIGN).dfu

--- a/hdl/verilog/blink/Makefile
+++ b/hdl/verilog/blink/Makefile
@@ -1,8 +1,3 @@
-# Simple Fomu Makefile
-# --------------------
-# This Makefile shows the steps to generate a DFU loadable image onto
-# Fomu hacker board.
-
 include ../../board.mk
 
 DESIGN = blink
@@ -14,6 +9,8 @@ YOSYS     ?= yosys
 NEXTPNR   ?= nextpnr-ice40
 ICEPACK   ?= icepack
 
+QUIET = @
+
 # If a container engine is used, each tool is executed in a separated container
 ifdef CONTAINER_ENGINE
 include ../../container.mk
@@ -21,49 +18,25 @@ endif
 
 # Default target: run all required targets to build the DFU image.
 all: $(DESIGN).dfu
-	@true
+	$(QUIET) echo "Built '$(DESIGN)' for Fomu $(FOMU_REV)"
 
 .DEFAULT: all
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
 $(DESIGN).json: $(VERILOG_SYN_FILES)
-	$(YOSYS) $(YOSYSFLAGS) \
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
 		-p  \
 		"synth_ice40 \
 		-top $(TOP) \
 		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
 
-# Use **nextpnr** to generate the FPGA configuration.
-# This is called the **place** and **route** step.
-$(DESIGN).asc: $(DESIGN).json $(PCF)
-	$(NEXTPNR) \
-		$(PNRFLAGS) \
-		--pcf $(PCF) \
-		--json  $< \
-		--asc $@
-
-# Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
-# This is called the bitstream generation step.
-$(DESIGN).bit: $(DESIGN).asc
-	$(ICEPACK) $< $@
-
-# Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-$(DESIGN).dfu: $(DESIGN).bit
-	cp $< $@
-	dfu-suffix -v 1209 -p 70b1 -a $@
-
-# Use df-util to load the DFU image onto the Fomu.
-load: $(DESIGN).dfu
-	dfu-util -D  $<
+include ../../PnR_Prog.mk
 
 .PHONY: load
 
 # Cleanup the generated files.
 clean:
-	-rm -f $(DESIGN).json 	# Generate netlist
-	-rm -f $(DESIGN).asc 	# FPGA configuration
-	-rm -f $(DESIGN).bit 	# FPGA bitstream
-	-rm -f $(DESIGN).dfu 	# DFU image loadable onto the Fomu
+	rm -fr *.json *-report.txt *.asc *.bit *.dfu
 
 .PHONY: clean

--- a/hdl/vhdl/blink/Makefile
+++ b/hdl/vhdl/blink/Makefile
@@ -12,6 +12,8 @@ YOSYS      ?= yosys
 NEXTPNR    ?= nextpnr-ice40
 ICEPACK    ?= icepack
 
+QUIET = @
+
 # If ghdl-yosys-plugin is built as a module (not the case with fomu-toolchain)
 ifdef GHDL_PLUGIN_MODULE
 YOSYSFLAGS += -m $(GHDL_PLUGIN_MODULE)
@@ -23,43 +25,22 @@ include ../../container.mk
 endif
 
 # Default target: run all required targets to build the DFU image.
-all: blink.dfu
-	@true
+all: $(DESIGN).dfu
+	$(QUIET) echo "Built '$(DESIGN)' for Fomu $(FOMU_REV)"
 
 .DEFAULT: all
 
 # Use *Yosys* to generate the synthesized netlist.
 # This is called the **synthesis** and **tech mapping** step.
 $(DESIGN).json: $(VHDL_SYN_FILES)
-	$(YOSYS) $(YOSYSFLAGS) \
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
 		-p \
 		"$(GHDLSYNTH) $(GHDL_FLAGS) $^ -e; \
 		synth_ice40 \
 		-top $(TOP) \
 		-json $@" 2>&1 | tee yosys-report.txt
 
-# Use **nextpnr** to generate the FPGA configuration.
-# This is called the **place** and **route** step.
-$(DESIGN).asc: $(DESIGN).json $(PCF)
-	$(NEXTPNR) \
-		$(PNRFLAGS) \
-		--pcf $(PCF) \
-		--json $< \
-		--asc $@
-
-# Use icepack to convert the FPGA configuration into a "bitstream" loadable onto the FPGA.
-# This is called the bitstream generation step.
-$(DESIGN).bit: $(DESIGN).asc
-	$(ICEPACK) $< $@
-
-# Use dfu-suffix to generate the DFU image from the FPGA bitstream.
-$(DESIGN).dfu: $(DESIGN).bit
-	cp $< $@
-	dfu-suffix -v 1209 -p 70b1 -a $@
-
-# Use df-util to load the DFU image onto the Fomu.
-load: $(DESIGN).dfu
-	dfu-util -D $<
+include ../../PnR_Prog.mk
 
 .PHONY: load
 


### PR DESCRIPTION
This PR includes several non critical updates:

- `hdl/PnR_Prog.mk` is added, for reducing duplication in the Makefiles used for Verilog and/or VHDL examples.
- MSYS2 jobs are added to CI, for testing that examples can be used by installing tools through `pacman`, instead of using fomu-toolchain.
- The README is updated. Some references were wrong, and other were missing.
- Litex example `workflow_rgb` was not tested in CI. I added it.