### PR TITLE
docs/migen: fix binary path

### DIFF
--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -30,28 +30,34 @@ echo '::endgroup::'
 
 echo '::group::LiteX example for Hacker'
 (
-	set -x
+	set -ex
 	cd litex
 	./workshop.py --board=hacker
-	file build/gateware/top.dfu
+	file build/gateware/fomu_hacker.dfu
+	file build/gateware/fomu_hacker.bin
+	rm -rf build        
 )
 echo '::endgroup::'
 
 echo '::group::LiteX example for PVT'
 (
-	set -x
+	set -ex
 	cd litex
 	./workshop.py --board=pvt
-	file build/gateware/top.dfu
+	file build/gateware/fomu_pvt.dfu
+	file build/gateware/fomu_pvt.bin
+	rm -rf build        
 )
 echo '::endgroup::'
 
 echo '::group::LiteX RGB example for PVT'
 (
-	set -x
+	set -ex
 	cd litex
 	./workshop_rgb.py --board=pvt
-	file build/gateware/top.dfu
+	file build/gateware/fomu_pvt.dfu
+	file build/gateware/fomu_pvt.bin
+	rm -rf build        
 )
 echo '::endgroup::'
 

--- a/docs/migen.rst
+++ b/docs/migen.rst
@@ -75,7 +75,7 @@ Load it onto Fomu:
 
 .. session:: shell-session
 
-   $ dfu-util -D build/gateware/top.dfu
+   $ dfu-util -D build/gateware/fomu_$FOMU_REV.bin
    dfu-util 0.8
    Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
    Copyright 2010-2014 Tormod Volden and Stefan Schmidt


### PR DESCRIPTION
The path seems to be dependent of the board revision now, updated it to use `$FOMU_REV` appropriately.
