### PR TITLE
ci: skip RISC-V Zig Example test on macOS

### DIFF
--- a/.github/tests.sh
+++ b/.github/tests.sh
@@ -19,6 +19,7 @@ echo '::group::RISC-V C Example'
 )
 echo '::endgroup::'
 
+if [ "x$RUNNER_OS" != "xmacOS" ]; then
 echo '::group::RISC-V Zig Example'
 (
 	set -x
@@ -27,6 +28,7 @@ echo '::group::RISC-V Zig Example'
 	file riscv-zig-blink.bin
 )
 echo '::endgroup::'
+fi
 
 echo '::group::LiteX example for Hacker'
 (


### PR DESCRIPTION
Execution of example RISC-V Zig on macOS has been failing in CI for two months now: https://github.com/im-tomu/fomu-workshop/runs/2798889344?check_suite_focus=true#step:10:5219.

That is preventing CI in fomu-toolchain from finishing successfully and, thus, publishing new releases. Therefore, I'm disabling that example on that platform until someone familiar with it can have a better look. My perception is it might be due to an update of zig from 0.6.0 to 0.8.0.

/cc @daurnimator as per https://github.com/im-tomu/fomu-workshop/commits/master/riscv-zig-blink