### PR TITLE
docs: remove unused dependency 'symbolator'

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,8 +18,6 @@ Other sphinx extensions which are used include;
   generate nice diagrams from Verilog examples.
 - [`sphinx-wavedrom`](https://github.com/bavovanachte/sphinx-wavedrom) to
   generate [nice waveform diagrams](http://wavedrom.com/). `sphinxcontrib-wavedrom`?
-- [`symbolator`](https://kevinpt.github.io/symbolator/) to generate block level
-  diagrams from Verilog examples.
 - [`sphinx_tabs`](https://github.com/djungelorm/sphinx-tabs) to support tabs
   for different Linux / Windows / Mac OS X instructions.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.githubpages',
     'sphinx.ext.extlinks',
-    'symbolator_sphinx',
     'sphinxcontrib_hdl_diagrams',
     'sphinx_tabs.tabs',
     'sphinxcontrib_session',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,18 +12,10 @@ sphinx_tabs
 # Support copying without prompts.
 git+https://github.com/mithro/sphinxcontrib-session.git#egg=sphinxcontrib-session
 
-# C API
-# --------------------------------------
-
-
-# HDL specific functionality
-# --------------------------------------
+#- HDL specific functionality
 
 # Wavedrom diagrams!
 sphinxcontrib-wavedrom
-
-# Model diagrams from Verilog code.
-symbolator
 
 # Verilog diagrams using Yosys + netlistsvg
 git+https://github.com/SymbiFlow/sphinxcontrib-hdl-diagrams.git#egg=sphinxcontrib-hdl-diagrams


### PR DESCRIPTION
Building the docs in CI is failing because symbolator cannot be installed properly. However, it seems that it is not being used. This PR removes the dependency.