### PR TITLE
doc: Add comment on /dev/ttyACM permissions and dialout group

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -47,6 +47,25 @@ Use ``dfu-util`` to load it:
 
            $ screen /dev/ttyACM*
 
+        If you are unable to connect you may need ``sudo`` access unless you
+        grant permission for using the serial device from a non-privileged
+        account.
+
+        .. session:: shell-session
+
+           $ ls -alh /dev/ttyACM*
+           crw-rw---- 1 root dialout 166, 0 Nov  9 21:28 /dev/ttyACM0
+
+           $ sudo usermod -a -G dialout $USER
+
+        .. WARNING::
+          You **must** log out and then log in again for the addition to group
+          ``dialout`` to take affect.
+
+        .. WARNING::
+          Adding your user to the ``dialout`` group grants full and direct
+          access to serial ports.
+
    .. group-tab:: Windows
 
         If you’re running a version of Windows earlier than Windows 10, you will

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -49,7 +49,11 @@ Use ``dfu-util`` to load it:
 
         If you are unable to connect you may need ``sudo`` access unless you
         grant permission for using the serial device from a non-privileged
-        account.
+        account by adding that account to the ``dialout`` group.
+
+        .. WARNING::
+          Adding your user to the ``dialout`` group grants full and direct
+          access to serial ports.
 
         .. session:: shell-session
 
@@ -61,10 +65,6 @@ Use ``dfu-util`` to load it:
         .. WARNING::
           You **must** log out and then log in again for the addition to group
           ``dialout`` to take affect.
-
-        .. WARNING::
-          Adding your user to the ``dialout`` group grants full and direct
-          access to serial ports.
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
Addresses #75.

Modeled on the udev section on adding a user to the `plugdev` group.

https://workshop.fomu.im/en/latest/requirements/drivers.html#steps-to-set-up-udev-rule