### PR TITLE
get_toolchain: Fix platform detection

### DIFF
--- a/get-toolchain.py
+++ b/get-toolchain.py
@@ -18,11 +18,11 @@ else:
 
 def platform():
     if 'linux' in sys.platform:
-        return 'linux'
+        return 'Linux'
     elif 'darwin' in sys.platform:
-        return 'mac'
+        return 'macOS'
     elif 'win' in sys.platform or 'msys' in sys.platform:
-        return 'windows'
+        return 'Windows'
     else:
         return sys.platform
 
@@ -107,14 +107,6 @@ def main(argv):
 
     plat = platform()
     print("Platform:", plat)
-
-    if os.environ.get('CI', False):
-        platforms = {
-            "windows": "Windows",
-            "linux": "Linux",
-            "mac": "macOS"
-        }
-        plat = platforms[plat]
 
     to_download = []
 


### PR DESCRIPTION
The platform lookup table is not used if the 'CI' env variable is not set, breaking the toolchain download.