### PR TITLE
Recent version of yosys need read_verilog command

### DIFF
--- a/hdl/mixed/blink/Makefile
+++ b/hdl/mixed/blink/Makefile
@@ -46,9 +46,10 @@ $(DESIGN).json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
 	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
 		-p \
 		"$(GHDLSYNTH) $(GHDL_FLAGS) $(VHDL_SYN_FILES) -e; \
+		read_verilog $(VERILOG_SYN_FILES); \
 		synth_ice40 \
 		-top $(TOP) \
-		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
+		-json $@" 2>&1 | tee yosys-report.txt
 
 include ../../PnR_Prog.mk
 


### PR DESCRIPTION
Recent version of yosys changed default behavior when reading verilog file. Seem we must use read_verilog command. So the command

```
$(DESIGN).json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
		-p \
		"$(GHDLSYNTH) $(GHDL_FLAGS) $(VHDL_SYN_FILES) -e; \
		synth_ice40 \
		-top $(TOP) \
		-json $@" $(VERILOG_SYN_FILES) 2>&1 | tee yosys-report.txt
``` 

must be changed to 
```
$(DESIGN).json: $(VHDL_SYN_FILES) $(VERILOG_SYN_FILES)
	$(QUIET) $(YOSYS) $(YOSYSFLAGS) \
		-p \
		"$(GHDLSYNTH) $(GHDL_FLAGS) $(VHDL_SYN_FILES) -e; \
		read_verilog $(VERILOG_SYN_FILES); \
		synth_ice40 \
		-top $(TOP) \
		-json $@" 2>&1 | tee yosys-report.txt
```