### PR TITLE
riscv-zig-blink example improvements

### DIFF
--- a/riscv-zig-blink/build.zig
+++ b/riscv-zig-blink/build.zig
@@ -21,15 +21,7 @@ pub fn build(b: *Builder) void {
         elf.setOutputDir(".");
     }
 
-    const binary = b.addSystemCommand(&[_][]const u8{
-        b.option([]const u8, "objcopy", "objcopy executable to use (defaults to riscv64-unknown-elf-objcopy)") orelse "riscv64-unknown-elf-objcopy",
-        "-I",
-        "elf32-littleriscv",
-        "-O",
-        "binary",
-    });
-    binary.addArtifactArg(elf);
-    binary.addArg("riscv-zig-blink.bin");
+    const binary = elf.installRaw("riscv-zig-blink.bin", .{ .dest_dir = .{ .custom = "../" } });
     b.default_step.dependOn(&binary.step);
 
     const run_cmd = b.addSystemCommand(&[_][]const u8{

--- a/riscv-zig-blink/build.zig
+++ b/riscv-zig-blink/build.zig
@@ -29,6 +29,13 @@ pub fn build(b: *Builder) void {
         "-D",
         "riscv-zig-blink.bin",
     });
+
+    // Blinky example does not support USB, so when dfu-util uses libusb
+    // to reset FOMU after flashing, it is no longer visible.
+    // libusb returns LIBUSB_ERROR_NOT_FOUND (-5) and dfu-util recognizes
+    // it as an error and returns EX_IOERR (74).
+    run_cmd.expected_exit_code = 74;
+
     run_cmd.step.dependOn(&binary.step);
     const run_step = b.step("run", "Upload and run the app on your FOMU");
     run_step.dependOn(&run_cmd.step);

--- a/riscv-zig-blink/src/fomu/messible.zig
+++ b/riscv-zig-blink/src/fomu/messible.zig
@@ -36,7 +36,7 @@ pub const MESSIBLE = struct {
 
     pub fn write(data: []const u8) usize {
         for (data) |c, i| {
-            if (STATUS.*.FULL) return i;
+            if (STATUS.FULL) return i;
             IN.* = c;
         }
         return data.len;
@@ -44,7 +44,7 @@ pub const MESSIBLE = struct {
 
     pub fn read(dst: []u8) usize {
         for (dst) |*c, i| {
-            if (!STATUS.*.HAVE) return i;
+            if (!STATUS.HAVE) return i;
             c.* = OUT.*;
         }
         return dst.len;


### PR DESCRIPTION
* remove `riscv64-unknown-elf-objcopy` dependency - Zig can emit bin file on its own
* set expected exit code to `74` so `zig build run` does not fail on successful binary upload
* small syntactic fix for unnecessary pointer dereferencing