### PR TITLE
docs/requirements: bump sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-docutils
-sphinx<4.0.0
+sphinx>=4.5.0
 sphinx-autobuild
 
 # Better looking Sphinx theme


### PR DESCRIPTION
This fixes the docs/RTD build failure related to jinja.