### PR TITLE
Add the `build` definition to `.readthedocs.yml`.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-lts-latest
+  tools:
+    # Need to use mambaforge as miniconda runs out of memory on rtd.
+    python: mambaforge-latest
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Fixes https://github.com/im-tomu/fomu-workshop/issues/825.