### PR TITLE
docs: install and load sphinxcontrib.jquery and add build section to readthedocs.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,5 +12,10 @@ sphinx:
 #formats:
 #- htmlzip
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-22.9"
+
 conda:
   environment: docs/environment.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ author = 'Tomu Project Authors'
 # ones.
 extensions = [
 #    'sphinx.ext.intersphinx',
+    'sphinxcontrib.jquery',
     'sphinx.ext.todo',
     'sphinx.ext.githubpages',
     'sphinx.ext.extlinks',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=4.5.0
 sphinx-autobuild
+sphinxcontrib-jquery
 
 # Better looking Sphinx theme
 # sphinx_materialdesign_theme


### PR DESCRIPTION
This fixes sphinxcontrib.jquery not being loaded automatically (see: https://github.com/readthedocs/sphinx_rtd_theme/issues/1452)

fixes #827
fixes #825 